### PR TITLE
Allow ImportError to work in Python 2 and 3.

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -34,7 +34,7 @@ lib = find_library('fluidsynth') or \
 
 
 if lib is None:
-    raise ImportError, "Couldn't find the FluidSynth library."
+    raise ImportError("Couldn't find the FluidSynth library.")
 
 
 # Dynamically link the FluidSynth library


### PR DESCRIPTION
The former syntax for raising Exceptions does not work in Python 3, but this change allows pyfluidsynth to work in both versions of Python.