### PR TITLE
Ensure python 2/3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ generally files with the extension SF2.  FluidSynth can either be used
 to play audio itself, or you can call a function that returns chunks
 of audio data and output the data to the soundcard yourself.
 ''',
-       py_modules = ['fluidsynth'])
+       py_modules = ['fluidsynth'],
+       install_requires = ['future'])


### PR DESCRIPTION
Make sure c-binding expecting char* are passed byte strings (b"",
a.encode())

Move from dict.iteritems() to future.utils.iteritems(dict) for py2/3
compat.

Convert strings to bytes for settings

work towards python2/3 compat

Fix error in device name handling for c-binding

----

Most of these changes were made in eed1224f27 and 6cdb00c16fa but reverted inadvertently in 650f872c85e. I just put them back and checked it imported nicely on 2 and 3.