### PR TITLE
Merged Use np.frombuffer instead of np.fromstring to avoid DeprecationWarning.

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -391,7 +391,7 @@ def fluid_synth_write_s16_stereo(synth, len):
     import numpy
     buf = create_string_buffer(len * 4)
     fluid_synth_write_s16(synth, len, buf, 0, 2, buf, 1, 2)
-    return numpy.fromstring(buf[:], dtype=numpy.int16)
+    return numpy.frombuffer(buf[:], dtype=numpy.int16)
 
 
 # Object-oriented interface, simplifies access to functions


### PR DESCRIPTION
Example warning:
```
/usr/local/lib/python2.7/dist-packages/fluidsynth.py:394: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
  return numpy.fromstring(buf[:], dtype=numpy.int16)
```