### PR TITLE
Change basestring to string

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -421,7 +421,7 @@ class Synth:
     def setting(self, opt, val):
         """change an arbitrary synth setting, type-smart"""
         opt = opt.encode()
-        if isinstance(val, basestring):
+        if isinstance(val, str):
             fluid_settings_setstr(self.settings, opt, val)
         elif isinstance(val, int):
             fluid_settings_setint(self.settings, opt, val)


### PR DESCRIPTION
Basestring does not exist in python 3, so replace with str for full (as far as I can tell) python 3 compatability