### PR TITLE
FluidSynth 2 compatibility

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -214,8 +214,7 @@ fluid_synth_handle_midi_event = cfunc('fluid_synth_handle_midi_event', POINTER(c
 try:
     new_fluid_cmd_handler=cfunc('new_fluid_cmd_handler', c_void_p,
                                    ('synth', c_void_p, 1),
-#                                  ('router', c_void_p, 1))
-                                   ('router', POINTER(fluid_midi_router_t), 1))
+                                   ('router', c_void_p, 1))
 
     fluid_synth_get_program = cfunc('fluid_synth_get_program', c_int,
                                     ('synth', c_void_p, 1),
@@ -495,7 +494,7 @@ class Synth:
     def setting(self, opt, val):
         """change an arbitrary synth setting, type-smart"""
         opt = opt.encode()
-        if isinstance(val, basestring):
+        if isinstance(val, str):
             fluid_settings_setstr(self.settings, opt, val)
         elif isinstance(val, int):
             fluid_settings_setint(self.settings, opt, val)

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -239,12 +239,6 @@ try:
                                    ('banknum', c_int, 1),
                                    ('prognum', c_int, 1))
 
-    fluid_synth_get_chorus_speed = cfunc('fluid_synth_get_chorus_speed', c_double,
-                                         ('synth', c_void_p, 1))
-
-    fluid_synth_get_chorus_depth = cfunc('fluid_synth_get_chorus_depth', c_double,
-                                         ('synth', c_void_p, 1))
-
     fluid_synth_set_reverb_roomsize = cfunc('fluid_synth_set_reverb_roomsize', c_int,
                                         ('synth', c_void_p, 1),
                                         ('roomsize', c_double, 1))
@@ -281,6 +275,27 @@ try:
                                         ('synth', c_void_p, 1),
                                         ('depth', c_double, 1))
 
+    fluid_synth_set_reverb = cfunc('fluid_synth_set_reverb', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('roomsize', c_double, 1),
+                                        ('damping', c_double, 1),
+                                        ('width', c_double, 1),
+                                        ('level', c_double, 1))
+
+    fluid_synth_set_chorus = cfunc('fluid_synth_set_chorus', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('nr', c_int, 1),
+                                        ('level', c_double, 1),
+                                        ('speed', c_double, 1),
+                                        ('depth_ms', c_double, 1),
+                                        ('type', c_int, 1))
+                                            
+    fluid_synth_get_chorus_speed = cfunc('fluid_synth_get_chorus_speed', c_double,
+                                         ('synth', c_void_p, 1))
+
+    fluid_synth_get_chorus_depth = cfunc('fluid_synth_get_chorus_depth', c_double,
+                                         ('synth', c_void_p, 1))
+
 except AttributeError:
     fluid_synth_set_midi_router = cfunc('fluid_synth_set_midi_router', None,
                                    ('synth', c_void_p, 1),
@@ -300,12 +315,6 @@ except AttributeError:
                                       ('chan', c_int, 1),
                                       ('info', POINTER(fluid_synth_channel_info_t), 1))
                                       
-    fluid_synth_get_chorus_speed_Hz = cfunc('fluid_synth_get_chorus_speed_Hz', c_double,
-                                        ('synth', c_void_p, 1))
-
-    fluid_synth_get_chorus_depth_ms = cfunc('fluid_synth_get_chorus_depth_ms', c_double,
-                                        ('synth', c_void_p, 1))
-                                        
     fluid_synth_set_reverb_full = cfunc('fluid_synth_set_reverb_full', c_int,
                                         ('synth', c_void_p, 1),
                                         ('set', c_int, 1),
@@ -322,6 +331,12 @@ except AttributeError:
                                         ('speed', c_double, 1),
                                         ('depth_ms', c_double, 1),
                                         ('type', c_int, 1))
+                                            
+    fluid_synth_get_chorus_speed_Hz = cfunc('fluid_synth_get_chorus_speed_Hz', c_double,
+                                        ('synth', c_void_p, 1))
+
+    fluid_synth_get_chorus_depth_ms = cfunc('fluid_synth_get_chorus_depth_ms', c_double,
+                                        ('synth', c_void_p, 1))
                                         
 fluid_synth_get_reverb_roomsize = cfunc('fluid_synth_get_reverb_roomsize', c_double,
                                     ('synth', c_void_p, 1))
@@ -344,7 +359,6 @@ fluid_synth_get_chorus_level = cfunc('fluid_synth_get_chorus_level', c_double,
 
 fluid_synth_get_chorus_type = cfunc('fluid_synth_get_chorus_type', c_int,
                                     ('synth', c_void_p, 1))
-
 
 # fluid sequencer
 new_fluid_sequencer2 = cfunc('new_fluid_sequencer2', c_void_p,
@@ -621,23 +635,14 @@ class Synth:
         if self.router is not None:
             fluid_midi_router_rule_set_param2(self.router.cmd_rule, min, max, mul, add)
     def set_reverb(self, roomsize=-1.0, damping=-1.0, width=-1.0, level=-1.0):
-        """                                  
-        roomsize Reverb room size value (0.0-1.2)
+        """
+        roomsize Reverb room size value (0.0-1.0)
         damping Reverb damping value (0.0-1.0)
         width Reverb width value (0.0-100.0)
         level Reverb level value (0.0-1.0)
         """
         try:
-            ret=FLUID_OK
-            if roomsize>=0:
-                ret=FLUID_FAILED if self.set_reverb_roomsize(roomsize) == FLUID_FAILED else ret
-            if damping>=0:
-                ret=FLUID_FAILED if self.set_reverb_damping(damping) == FLUID_FAILED else ret
-            if width>=0:
-                ret=FLUID_FAILED if self.set_reverb_width(width) == FLUID_FAILED else ret
-            if level>=0:
-                ret=FLUID_FAILED if self.set_reverb_level(level) == FLUID_FAILED else ret
-            return ret
+            return fluid_synth_set_reverb(self.synth, roomsize, damping, width, level)
         except NameError:
             set=0
             if roomsize>=0:
@@ -658,18 +663,7 @@ class Synth:
         type Chorus waveform type (0=sine, 1=triangle)
         """
         try:
-            ret=FLUID_OK
-            if nr>=0:
-                ret=FLUID_FAILED if self.set_chorus_nr(nr) == FLUID_FAILED else ret
-            if level>=0:
-                ret=FLUID_FAILED if self.set_chorus_level(level) == FLUID_FAILED else ret
-            if speed>=0:
-                ret=FLUID_FAILED if self.set_chorus_speed(speed) == FLUID_FAILED else ret
-            if depth>=0:
-                ret=FLUID_FAILED if self.set_chorus_depth(depth) == FLUID_FAILED else ret
-            if type>=0:
-                ret=FLUID_FAILED if self.set_chorus_type(type) == FLUID_FAILED else ret
-            return ret
+            return fluid_synth_set_reverb(self.synth, roomsize, damping, width, level)
         except NameError:
             set=0
             if nr>=0:

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -112,6 +112,21 @@ fluid_synth_program_select = cfunc('fluid_synth_program_select', c_int,
                                    ('bank', c_int, 1),
                                    ('preset', c_int, 1))
 
+fluid_synth_unset_program = cfunc('fluid_synth_unset_program', c_int,
+                                   ('synth', c_void_p, 1),
+                                   ('chan', c_int, 1))
+
+fluid_synth_get_program = cfunc('fluid_synth_get_program', c_int,
+                                ('synth', c_void_p, 1),
+                                ('chan', c_int, 1),
+                                ('sfont_id', POINTER(c_int), 1),
+                                ('bank_num', POINTER(c_int), 1),
+                                ('preset_num', POINTER(c_int), 1))
+                                
+fluid_synth_get_sfont_by_id = cfunc('fluid_synth_get_sfont_by_id', c_void_p,
+                                    ('synth', c_void_p, 1),
+                                    ('id', c_int, 1))
+
 fluid_synth_noteon = cfunc('fluid_synth_noteon', c_int,
                            ('synth', c_void_p, 1),
                            ('chan', c_int, 1),
@@ -216,13 +231,6 @@ try:
                                    ('synth', c_void_p, 1),
                                    ('router', c_void_p, 1))
 
-    fluid_synth_get_program = cfunc('fluid_synth_get_program', c_int,
-                                    ('synth', c_void_p, 1),
-                                    ('chan', c_int, 1),
-                                    ('sfont_id', POINTER(c_int), 1),
-                                    ('bank_num', POINTER(c_int), 1),
-                                    ('preset_num', POINTER(c_int), 1))
-                                    
     fluid_preset_get_name = cfunc('fluid_preset_get_name', c_char_p,
                                   ('preset', c_void_p, 1))
 
@@ -230,10 +238,6 @@ try:
                                    ('sfont', c_void_p, 1),
                                    ('banknum', c_int, 1),
                                    ('prognum', c_int, 1))
-
-    fluid_synth_get_sfont_by_id = cfunc('fluid_synth_get_sfont_by_id', c_void_p,
-                                        ('synth', c_void_p, 1),
-                                        ('id', c_int, 1))
 
     fluid_synth_get_chorus_speed = cfunc('fluid_synth_get_chorus_speed', c_double,
                                          ('synth', c_void_p, 1))
@@ -548,11 +552,13 @@ class Synth:
     def program_select(self, chan, sfid, bank, preset):
         """Select a program"""
         return fluid_synth_program_select(self.synth, chan, sfid, bank, preset)
+    def program_unset(self, chan):
+        """Set the preset of a MIDI channel to an unassigned state"""
+        return fluid_synth_unset_program(self.synth, chan)
     def channel_info(self, chan):
         """
         get soundfont, bank, prog, preset name of channel
         superceded by program_info and sfpreset_name, included for backwards-compatibility
-        should maybe be deprecated as there's a good chance I'm the only one who used it
         """
         try:
             info=fluid_synth_channel_info_t()

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -7,7 +7,7 @@
 
     Copyright 2008, Nathan Whitehead <nwhitehe@gmail.com>
 
-    
+
     Released under the LGPL
 
     This module contains python bindings for FluidSynth.  FluidSynth is a
@@ -22,12 +22,19 @@
 ================================================================================
 
 Added lots of bindings and stuff to help with playing live -- Bill Peterson <albedozero@gmail.com>
+Added sequencer support -- Christian Romberg <distjubo@gmail.com>
+Tried to build in fluidsynth 2 capability while maintaining backwards compatibility -- Bill Peterson <albedozero@gmail.com>
 """
 
-import time
 from ctypes import *
 from ctypes.util import find_library
 
+# Python2-3 compatibility hack
+try:
+    str
+except NameError:
+    str = basestring
+  
 # A short circuited or expression to find the FluidSynth library
 # (mostly needed for Windows distributions of libfluidsynth supplied with QSynth)
 
@@ -37,7 +44,7 @@ lib = find_library('fluidsynth') or \
 
 if lib is None:
     raise ImportError("Couldn't find the FluidSynth library.")
-
+    
 # Dynamically link the FluidSynth library
 _fl = CDLL(lib)
 
@@ -53,41 +60,40 @@ def cfunc(name, result, *args):
 
 
 # Bump this up when changing the interface for users
-api_version = '1.2.2'
+api_version = '1.3'
 
 # Function prototypes for C versions of functions
+
+FLUID_OK = 0
+FLUID_FAILED = -1
+
+# fluid settings
 new_fluid_settings = cfunc('new_fluid_settings', c_void_p)
 
-new_fluid_synth = cfunc('new_fluid_synth', c_void_p,
-                        ('settings', c_void_p, 1))
-
-new_fluid_audio_driver = cfunc('new_fluid_audio_driver', c_void_p,
-                               ('settings', c_void_p, 1),
-                               ('synth', c_void_p, 1))
-
-fluid_settings_setstr = cfunc('fluid_settings_setstr', c_int, 
+fluid_settings_setstr = cfunc('fluid_settings_setstr', c_int,
                               ('settings', c_void_p, 1),
                               ('name', c_char_p, 1),
                               ('str', c_char_p, 1))
 
-fluid_settings_setnum = cfunc('fluid_settings_setnum', c_int, 
+fluid_settings_setnum = cfunc('fluid_settings_setnum', c_int,
                               ('settings', c_void_p, 1),
                               ('name', c_char_p, 1),
                               ('val', c_double, 1))
 
-fluid_settings_setint = cfunc('fluid_settings_setint', c_int, 
+fluid_settings_setint = cfunc('fluid_settings_setint', c_int,
                               ('settings', c_void_p, 1),
                               ('name', c_char_p, 1),
                               ('val', c_int, 1))
 
-delete_fluid_audio_driver = cfunc('delete_fluid_audio_driver', None,
-                                  ('driver', c_void_p, 1))
+delete_fluid_settings = cfunc('delete_fluid_settings', None,
+                              ('settings', c_void_p, 1))
+
+# fluid synth
+new_fluid_synth = cfunc('new_fluid_synth', c_void_p,
+                        ('settings', c_void_p, 1))
 
 delete_fluid_synth = cfunc('delete_fluid_synth', None,
                            ('synth', c_void_p, 1))
-
-delete_fluid_settings = cfunc('delete_fluid_settings', None,
-                              ('settings', c_void_p, 1))
 
 fluid_synth_sfload = cfunc('fluid_synth_sfload', c_int,
                            ('synth', c_void_p, 1),
@@ -163,67 +169,17 @@ fluid_synth_write_s16 = cfunc('fluid_synth_write_s16', c_void_p,
                               ('lincr', c_int, 1),
                               ('rbuf', c_void_p, 1),
                               ('roff', c_int, 1),
-                              ('rincr', c_int, 1))                      
+                              ('rincr', c_int, 1))
 
-class fluid_synth_channel_info_t(Structure):
-    _fields_ = [
-        ('assigned', c_int),
-        ('sfont_id', c_int),
-        ('bank', c_int),
-        ('program', c_int),
-        ('name', c_char*32),
-        ('reserved', c_char*32)]
-                              
-fluid_synth_get_channel_info = cfunc('fluid_synth_get_channel_info', c_int,
-                                  ('synth', c_void_p, 1),
-                                  ('chan', c_int, 1),
-                                  ('info', POINTER(fluid_synth_channel_info_t), 1))
+# fluid audio driver
+new_fluid_audio_driver = cfunc('new_fluid_audio_driver', c_void_p,
+                               ('settings', c_void_p, 1),
+                               ('synth', c_void_p, 1))
 
-fluid_synth_set_reverb_full = cfunc('fluid_synth_set_reverb_full', c_int,
-                                    ('synth', c_void_p, 1),
-                                    ('set', c_int, 1),
-                                    ('roomsize', c_double, 1),
-                                    ('damping', c_double, 1),
-                                    ('width', c_double, 1),
-                                    ('level', c_double, 1))
-                                    
-fluid_synth_set_chorus_full = cfunc('fluid_synth_set_chorus_full', c_int,
-                                    ('synth', c_void_p, 1),
-                                    ('set', c_int, 1),
-                                    ('nr', c_int, 1),
-                                    ('level', c_double, 1),
-                                    ('speed', c_double, 1),
-                                    ('depth_ms', c_double, 1),
-                                    ('type', c_int, 1))
+delete_fluid_audio_driver = cfunc('delete_fluid_audio_driver', None,
+                                  ('driver', c_void_p, 1))
 
-fluid_synth_get_reverb_roomsize = cfunc('fluid_synth_get_reverb_roomsize', c_double,
-                                    ('synth', c_void_p, 1))
-
-fluid_synth_get_reverb_damp = cfunc('fluid_synth_get_reverb_damp', c_double,
-                                    ('synth', c_void_p, 1))
-
-fluid_synth_get_reverb_level = cfunc('fluid_synth_get_reverb_level', c_double,
-                                    ('synth', c_void_p, 1))
-
-fluid_synth_get_reverb_width = cfunc('fluid_synth_get_reverb_width', c_double,
-                                    ('synth', c_void_p, 1))
-
-                                    
-fluid_synth_get_chorus_nr = cfunc('fluid_synth_get_chorus_nr', c_int,
-                                    ('synth', c_void_p, 1))
-
-fluid_synth_get_chorus_level = cfunc('fluid_synth_get_chorus_level', c_double,
-                                    ('synth', c_void_p, 1))
-
-fluid_synth_get_chorus_speed_Hz = cfunc('fluid_synth_get_chorus_speed_Hz', c_double,
-                                    ('synth', c_void_p, 1))
-
-fluid_synth_get_chorus_depth_ms = cfunc('fluid_synth_get_chorus_depth_ms', c_double,
-                                    ('synth', c_void_p, 1))
-
-fluid_synth_get_chorus_type = cfunc('fluid_synth_get_chorus_type', c_int,
-                                    ('synth', c_void_p, 1))
-
+# fluid midi driver
 new_fluid_midi_driver = cfunc('new_fluid_midi_driver', c_void_p,
                                ('settings', c_void_p, 1),
                                ('handler', CFUNCTYPE(POINTER(c_int), c_void_p, c_void_p), 1),
@@ -246,34 +202,228 @@ new_fluid_midi_router = cfunc('new_fluid_midi_router', POINTER(fluid_midi_router
                                ('handler', CFUNCTYPE(POINTER(c_int), c_void_p, c_void_p), 1),
                                ('event_handler_data', c_void_p, 1))
 
-fluid_synth_set_midi_router = cfunc('fluid_synth_set_midi_router', None,
-                               ('synth', c_void_p, 1),
-                               ('router', c_void_p, 1))
-
+fluid_midi_router_handle_midi_event = cfunc('fluid_midi_router_handle_midi_event', POINTER(c_int),
+                               ('data', c_void_p, 1),
+                               ('event', c_void_p, 1))
+                               
 fluid_synth_handle_midi_event = cfunc('fluid_synth_handle_midi_event', POINTER(c_int),
                                ('data', c_void_p, 1),
                                ('event', c_void_p, 1))
 
-fluid_midi_router_handle_midi_event = cfunc('fluid_midi_router_handle_midi_event', POINTER(c_int),
-                               ('data', c_void_p, 1),
-                               ('event', c_void_p, 1))
+# some hacks for compatibility with fluidsynth <2
+try:
+    new_fluid_cmd_handler=cfunc('new_fluid_cmd_handler', c_void_p,
+                                   ('synth', c_void_p, 1),
+#                                  ('router', c_void_p, 1))
+                                   ('router', POINTER(fluid_midi_router_t), 1))
 
-fluid_midi_router_clear_rules = cfunc('fluid_midi_router_clear_rules', c_int,
-                                    ('router', POINTER(fluid_midi_router_t), 1))
-
-fluid_midi_router_set_default_rules = cfunc('fluid_midi_router_set_default_rules', c_int,
-                                    ('router', POINTER(fluid_midi_router_t), 1))
+    fluid_synth_get_program = cfunc('fluid_synth_get_program', c_int,
+                                    ('synth', c_void_p, 1),
+                                    ('chan', c_int, 1),
+                                    ('sfont_id', POINTER(c_int), 1),
+                                    ('bank_num', POINTER(c_int), 1),
+                                    ('preset_num', POINTER(c_int), 1))
                                     
+    fluid_preset_get_name = cfunc('fluid_preset_get_name', c_char_p,
+                                  ('preset', c_void_p, 1))
+
+    fluid_sfont_get_preset = cfunc('fluid_sfont_get_preset', c_void_p,
+                                   ('sfont', c_void_p, 1),
+                                   ('banknum', c_int, 1),
+                                   ('prognum', c_int, 1))
+
+    fluid_synth_get_sfont_by_id = cfunc('fluid_synth_get_sfont_by_id', c_void_p,
+                                        ('synth', c_void_p, 1),
+                                        ('id', c_int, 1))
+
+    fluid_synth_get_chorus_speed = cfunc('fluid_synth_get_chorus_speed', c_double,
+                                         ('synth', c_void_p, 1))
+
+    fluid_synth_get_chorus_depth = cfunc('fluid_synth_get_chorus_depth', c_double,
+                                         ('synth', c_void_p, 1))
+
+    fluid_synth_set_reverb_roomsize = cfunc('fluid_synth_set_reverb_roomsize', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('roomsize', c_double, 1))
+
+    fluid_synth_set_reverb_damp = cfunc('fluid_synth_set_reverb_damp', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('damping', c_double, 1))
+
+    fluid_synth_set_reverb_level = cfunc('fluid_synth_set_reverb_level', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('level', c_double, 1))
+
+    fluid_synth_set_reverb_width = cfunc('fluid_synth_set_reverb_width', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('width', c_double, 1))
+              
+    fluid_synth_set_chorus_nr = cfunc('fluid_synth_set_chorus_nr', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('nr', c_int, 1))
+
+    fluid_synth_set_chorus_level = cfunc('fluid_synth_set_chorus_level', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('level', c_double, 1))
+
+    fluid_synth_set_chorus_type = cfunc('fluid_synth_set_chorus_type', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('type', c_int, 1))
+
+    fluid_synth_set_chorus_speed = cfunc('fluid_synth_set_chorus_speed', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('speed', c_double, 1))
+
+    fluid_synth_set_chorus_depth = cfunc('fluid_synth_set_chorus_depth', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('depth', c_double, 1))
+
+except AttributeError:
+    fluid_synth_set_midi_router = cfunc('fluid_synth_set_midi_router', None,
+                                   ('synth', c_void_p, 1),
+                                   ('router', c_void_p, 1))
+
+    class fluid_synth_channel_info_t(Structure):
+        _fields_ = [
+            ('assigned', c_int),
+            ('sfont_id', c_int),
+            ('bank', c_int),
+            ('program', c_int),
+            ('name', c_char*32),
+            ('reserved', c_char*32)]
+
+    fluid_synth_get_channel_info = cfunc('fluid_synth_get_channel_info', c_int,
+                                      ('synth', c_void_p, 1),
+                                      ('chan', c_int, 1),
+                                      ('info', POINTER(fluid_synth_channel_info_t), 1))
+                                      
+    fluid_synth_get_chorus_speed_Hz = cfunc('fluid_synth_get_chorus_speed_Hz', c_double,
+                                        ('synth', c_void_p, 1))
+
+    fluid_synth_get_chorus_depth_ms = cfunc('fluid_synth_get_chorus_depth_ms', c_double,
+                                        ('synth', c_void_p, 1))
+                                        
+    fluid_synth_set_reverb_full = cfunc('fluid_synth_set_reverb_full', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('set', c_int, 1),
+                                        ('roomsize', c_double, 1),
+                                        ('damping', c_double, 1),
+                                        ('width', c_double, 1),
+                                        ('level', c_double, 1))
+
+    fluid_synth_set_chorus_full = cfunc('fluid_synth_set_chorus_full', c_int,
+                                        ('synth', c_void_p, 1),
+                                        ('set', c_int, 1),
+                                        ('nr', c_int, 1),
+                                        ('level', c_double, 1),
+                                        ('speed', c_double, 1),
+                                        ('depth_ms', c_double, 1),
+                                        ('type', c_int, 1))
+                                        
+fluid_synth_get_reverb_roomsize = cfunc('fluid_synth_get_reverb_roomsize', c_double,
+                                    ('synth', c_void_p, 1))
+
+fluid_synth_get_reverb_damp = cfunc('fluid_synth_get_reverb_damp', c_double,
+                                    ('synth', c_void_p, 1))
+
+fluid_synth_get_reverb_level = cfunc('fluid_synth_get_reverb_level', c_double,
+                                    ('synth', c_void_p, 1))
+
+fluid_synth_get_reverb_width = cfunc('fluid_synth_get_reverb_width', c_double,
+                                    ('synth', c_void_p, 1))
+
+                                    
+fluid_synth_get_chorus_nr = cfunc('fluid_synth_get_chorus_nr', c_int,
+                                    ('synth', c_void_p, 1))
+
+fluid_synth_get_chorus_level = cfunc('fluid_synth_get_chorus_level', c_double,
+                                    ('synth', c_void_p, 1))
+
+fluid_synth_get_chorus_type = cfunc('fluid_synth_get_chorus_type', c_int,
+                                    ('synth', c_void_p, 1))
+
+
+# fluid sequencer
+new_fluid_sequencer2 = cfunc('new_fluid_sequencer2', c_void_p,
+                             ('use_system_timer', c_int, 1))
+
+fluid_sequencer_process = cfunc('fluid_sequencer_process', None,
+                               ('seq', c_void_p, 1),
+                               ('msec', c_uint, 1))
+
+fluid_sequencer_register_fluidsynth = cfunc('fluid_sequencer_register_fluidsynth', c_short,
+                               ('seq', c_void_p, 1),
+                               ('synth', c_void_p, 1))
+
+fluid_sequencer_register_client = cfunc('fluid_sequencer_register_client', c_short,
+                              ('seq', c_void_p, 1),
+                              ('name', c_char_p, 1),
+                              ('callback', CFUNCTYPE(None, c_uint, c_void_p, c_void_p, c_void_p), 1),
+                              ('data', c_void_p, 1))
+
+fluid_sequencer_get_tick = cfunc('fluid_sequencer_get_tick', c_uint,
+                                ('seq', c_void_p, 1))
+
+fluid_sequencer_set_time_scale = cfunc('fluid_sequencer_set_time_scale', None,
+                                      ('seq', c_void_p, 1),
+                                      ('scale', c_double, 1))
+
+fluid_sequencer_get_time_scale = cfunc('fluid_sequencer_get_time_scale', c_double,
+                                      ('seq', c_void_p, 1))
+
+fluid_sequencer_send_at = cfunc('fluid_sequencer_send_at', c_int,
+                               ('seq', c_void_p, 1),
+                               ('evt', c_void_p, 1),
+                               ('time', c_uint, 1),
+                               ('absolute', c_int, 1))
+                               
+
+delete_fluid_sequencer = cfunc('delete_fluid_sequencer', None,
+                              ('seq', c_void_p, 1))
+
+# fluid event
+new_fluid_event = cfunc('new_fluid_event', c_void_p)
+
+fluid_event_set_source = cfunc('fluid_event_set_source', None,
+                              ('evt', c_void_p, 1),
+                              ('src', c_void_p, 1))
+
+fluid_event_set_dest = cfunc('fluid_event_set_dest', None,
+                            ('evt', c_void_p, 1),
+                            ('dest', c_void_p, 1))
+
+fluid_event_timer = cfunc('fluid_event_timer', None,
+                         ('evt', c_void_p, 1),
+                         ('data', c_void_p, 1))
+
+fluid_event_note = cfunc('fluid_event_note', None,
+                         ('evt', c_void_p, 1),
+                         ('channel', c_int, 1),
+                         ('key', c_short, 1),
+                         ('vel', c_short, 1),
+                         ('duration', c_uint, 1))
+
+fluid_event_noteon = cfunc('fluid_event_noteon', None,
+                         ('evt', c_void_p, 1),
+                         ('channel', c_int, 1),
+                         ('key', c_short, 1),
+                         ('vel', c_short, 1))
+
+fluid_event_noteoff = cfunc('fluid_event_noteoff', None,
+                         ('evt', c_void_p, 1),
+                         ('channel', c_int, 1),
+                         ('key', c_short, 1))
+
+
+delete_fluid_event = cfunc('delete_fluid_event', None,
+                          ('evt', c_void_p, 1))
+
+# fluid midi router rules
 delete_fluid_midi_router_rule = cfunc('delete_fluid_midi_router_rule', c_int,
                                     ('rule', c_void_p, 1))
                                     
 new_fluid_midi_router_rule = cfunc('new_fluid_midi_router_rule', c_void_p)
 
-fluid_midi_router_add_rule = cfunc('fluid_midi_router_add_rule', c_int,
-                                    ('router', POINTER(fluid_midi_router_t), 1),
-                                    ('rule', c_void_p, 1),
-                                    ('type', c_int, 1))
-                                    
 fluid_midi_router_rule_set_chan = cfunc('fluid_midi_router_rule_set_chan', None,
                                     ('rule', c_void_p, 1),
                                     ('min', c_int, 1),
@@ -294,6 +444,17 @@ fluid_midi_router_rule_set_param2 = cfunc('fluid_midi_router_rule_set_param2', N
                                     ('max', c_int, 1),
                                     ('mul', c_float, 1),
                                     ('add', c_int, 1))
+
+fluid_midi_router_clear_rules = cfunc('fluid_midi_router_clear_rules', c_int,
+                                    ('router', POINTER(fluid_midi_router_t), 1))
+
+fluid_midi_router_set_default_rules = cfunc('fluid_midi_router_set_default_rules', c_int,
+                                    ('router', POINTER(fluid_midi_router_t), 1))
+
+fluid_midi_router_add_rule = cfunc('fluid_midi_router_add_rule', c_int,
+                                    ('router', POINTER(fluid_midi_router_t), 1),
+                                    ('rule', c_void_p, 1),
+                                    ('type', c_int, 1))
         
 def fluid_synth_write_s16_stereo(synth, len):
     """Return generated samples in stereo 16-bit format
@@ -304,7 +465,7 @@ def fluid_synth_write_s16_stereo(synth, len):
     import numpy
     buf = create_string_buffer(len * 4)
     fluid_synth_write_s16(synth, len, buf, 0, 2, buf, 1, 2)
-    return numpy.fromstring(buf[:], dtype=numpy.int16)
+    return numpy.frombuffer(buf[:], dtype=numpy.int16)
 
 
 # Object-oriented interface, simplifies access to functions
@@ -321,10 +482,10 @@ class Synth:
         added capability for passing arbitrary fluid settings using args
         """
         st = new_fluid_settings()
-        fluid_settings_setnum(st, 'synth.gain', gain)
-        fluid_settings_setnum(st, 'synth.sample-rate', samplerate)
-        fluid_settings_setint(st, 'synth.midi-channels', channels)
-        for opt,val in kwargs.iteritems():
+        fluid_settings_setnum(st, b'synth.gain', gain)
+        fluid_settings_setnum(st, b'synth.sample-rate', samplerate)
+        fluid_settings_setint(st, b'synth.midi-channels', channels)
+        for opt,val in kwargs.items():
             self.setting(opt, val)
         self.settings = st
         self.synth = new_fluid_synth(st)
@@ -333,12 +494,13 @@ class Synth:
         self.router = None
     def setting(self, opt, val):
         """change an arbitrary synth setting, type-smart"""
+        opt = opt.encode()
         if isinstance(val, basestring):
             fluid_settings_setstr(self.settings, opt, val)
         elif isinstance(val, int):
             fluid_settings_setint(self.settings, opt, val)
         elif isinstance(val, float):
-            fluid_settings_setnum(self.settings, opt, val)            
+            fluid_settings_setnum(self.settings, opt, val)
     def start(self, driver=None, device=None, midi_driver=None):
         """Start audio output driver in separate background thread
 
@@ -359,16 +521,19 @@ class Synth:
 
         """
         if driver is not None:
-            assert (driver in ['alsa', 'oss', 'jack', 'portaudio', 'sndmgr', 'coreaudio', 'Direct Sound']) 
-            fluid_settings_setstr(self.settings, 'audio.driver', driver)
+            assert (driver in ['alsa', 'oss', 'jack', 'portaudio', 'sndmgr', 'coreaudio', 'Direct Sound', 'pulseaudio']) 
+            fluid_settings_setstr(self.settings, b'audio.driver', driver.encode())
             if device is not None:
-                fluid_settings_setstr(self.settings, 'audio.%s.device' % (driver), device)
+                fluid_settings_setstr(self.settings, str('audio.%s.device' % (driver)).encode(), device.encode())
             self.audio_driver = new_fluid_audio_driver(self.settings, self.synth)
         if midi_driver is not None:
             assert (midi_driver in ['alsa_seq', 'alsa_raw', 'oss', 'winmidi', 'midishare', 'coremidi'])
-            fluid_settings_setstr(self.settings, 'midi.driver', midi_driver)
+            fluid_settings_setstr(self.settings, b'midi.driver', midi_driver.encode())
             self.router = new_fluid_midi_router(self.settings, fluid_synth_handle_midi_event, self.synth)
-            fluid_synth_set_midi_router(self.synth, self.router)
+            try:
+                new_fluid_cmd_handler(self.synth, self.router)
+            except NameError:
+                fluid_synth_set_midi_router(self.synth, self.router)
             self.midi_driver = new_fluid_midi_driver(self.settings, fluid_midi_router_handle_midi_event, self.router)
     def delete(self):
         if self.audio_driver is not None:
@@ -377,7 +542,7 @@ class Synth:
         delete_fluid_settings(self.settings)
     def sfload(self, filename, update_midi_preset=0):
         """Load SoundFont and return its ID"""
-        return fluid_synth_sfload(self.synth, filename, update_midi_preset)
+        return fluid_synth_sfload(self.synth, filename.encode(), update_midi_preset)
     def sfunload(self, sfid, update_midi_preset=0):
         """Unload a SoundFont and free memory it used"""
         return fluid_synth_sfunload(self.synth, sfid, update_midi_preset)
@@ -385,10 +550,31 @@ class Synth:
         """Select a program"""
         return fluid_synth_program_select(self.synth, chan, sfid, bank, preset)
     def channel_info(self, chan):
-        """get soundfont, bank, prog, preset name of channel"""
-        info=fluid_synth_channel_info_t()
-        fluid_synth_get_channel_info(self.synth, chan, byref(info))
-        return (info.sfont_id, info.bank, info.program, info.name)
+        """
+        get soundfont, bank, prog, preset name of channel
+        superceded by program_info and sfpreset_name, included for backwards-compatibility
+        should maybe be deprecated as there's a good chance I'm the only one who used it
+        """
+        try:
+            info=fluid_synth_channel_info_t()
+            fluid_synth_get_channel_info(self.synth, chan, byref(info))
+            return (info.sfont_id, info.bank, info.program, info.name)
+        except NameError:
+            (sfontid, banknum, prognum) = self.program_info(chan)
+            return (sfontid, banknum, prognum, self.sfpreset_name(sfontid, banknum, prognum))
+    def program_info(self, chan):
+        sfontid=c_int()
+        banknum=c_int()
+        prognum=c_int()
+        fluid_synth_get_program(self.synth, chan, byref(sfontid), byref(banknum), byref(prognum))
+        return (sfontid.value, banknum.value, prognum.value)
+    def sfpreset_name(self, sfid, bank, prog):
+        """Return name of a soundfont preset as a pointer to string"""
+        sfont=fluid_synth_get_sfont_by_id(self.synth, sfid)
+        preset=fluid_sfont_get_preset(sfont, bank, prog)
+        if not preset:
+            return None
+        return fluid_preset_get_name(preset).decode('ascii')
     def router_clear(self):
         if self.router is not None:
             fluid_midi_router_clear_rules(self.router)
@@ -436,16 +622,28 @@ class Synth:
         width Reverb width value (0.0-100.0)
         level Reverb level value (0.0-1.0)
         """
-        set=0
-        if roomsize>=0:
-            set+=0b0001
-        if damping>=0:
-            set+=0b0010
-        if width>=0:
-            set+=0b0100
-        if level>=0:
-            set+=0b1000
-        return fluid_synth_set_reverb_full(self.synth, set, roomsize, damping, width, level)
+        try:
+            ret=FLUID_OK
+            if roomsize>=0:
+                ret=FLUID_FAILED if self.set_reverb_roomsize(roomsize) == FLUID_FAILED else ret
+            if damping>=0:
+                ret=FLUID_FAILED if self.set_reverb_damping(damping) == FLUID_FAILED else ret
+            if width>=0:
+                ret=FLUID_FAILED if self.set_reverb_width(width) == FLUID_FAILED else ret
+            if level>=0:
+                ret=FLUID_FAILED if self.set_reverb_level(level) == FLUID_FAILED else ret
+            return ret
+        except NameError:
+            set=0
+            if roomsize>=0:
+                set+=0b0001
+            if damping>=0:
+                set+=0b0010
+            if width>=0:
+                set+=0b0100
+            if level>=0:
+                set+=0b1000
+            return fluid_synth_set_reverb_full(self.synth, set, roomsize, damping, width, level)
     def set_chorus(self, nr=-1, level=-1.0, speed=-1.0, depth=-1.0, type=-1):
         """                                  
         nr Chorus voice count (0-99, CPU time consumption proportional to this value)
@@ -454,18 +652,50 @@ class Synth:
         depth_ms Chorus depth (max value depends on synth sample rate, 0.0-21.0 is safe for sample rate values up to 96KHz)
         type Chorus waveform type (0=sine, 1=triangle)
         """
-        set=0
-        if nr>=0:
-            set+=0b00001
-        if level>=0:
-            set+=0b00010
-        if speed>=0:
-            set+=0b00100
-        if depth>=0:
-            set+=0b01000
-        if type>=0:
-            set+=0b10000
-        return fluid_synth_set_chorus_full(self.synth, set, nr, level, speed, depth, type)
+        try:
+            ret=FLUID_OK
+            if nr>=0:
+                ret=FLUID_FAILED if self.set_chorus_nr(nr) == FLUID_FAILED else ret
+            if level>=0:
+                ret=FLUID_FAILED if self.set_chorus_level(level) == FLUID_FAILED else ret
+            if speed>=0:
+                ret=FLUID_FAILED if self.set_chorus_speed(speed) == FLUID_FAILED else ret
+            if depth>=0:
+                ret=FLUID_FAILED if self.set_chorus_depth(depth) == FLUID_FAILED else ret
+            if type>=0:
+                ret=FLUID_FAILED if self.set_chorus_type(type) == FLUID_FAILED else ret
+            return ret
+        except NameError:
+            set=0
+            if nr>=0:
+                set+=0b00001
+            if level>=0:
+                set+=0b00010
+            if speed>=0:
+                set+=0b00100
+            if depth>=0:
+                set+=0b01000
+            if type>=0:
+                set+=0b10000
+            return fluid_synth_set_reverb_full(self.synth, set, roomsize, damping, width, level)
+    def set_reverb_roomsize(self, roomsize):
+        return fluid_synth_set_reverb_roomsize(self.synth, roomsize)
+    def set_reverb_damp(self, damp):
+        return fluid_synth_set_reverb_damp(self.synth, damp)
+    def set_reverb_level(self, level):
+        return fluid_synth_set_reverb_level(self.synth, level)
+    def set_reverb_width(self, width):
+        return fluid_synth_set_reverb_width(self.synth, width)
+    def set_chorus_nr(self, nr):
+        return fluid_synth_set_chorus_nr(self.synth, nr)
+    def set_chorus_level(self, level):
+        return fluid_synth_set_reverb_level(self.synth, level)
+    def set_chorus_speed(self, speed):
+        return fluid_synth_set_chorus_speed(self.synth, speed)
+    def set_chorus_depth(self, depth):
+        return fluid_synth_set_chorus_depth(self.synth, depth)
+    def set_chorus_type(self, type):
+        return fluid_synth_set_chorus_type(self.synth, type)
     def get_reverb_roomsize(self):
         return fluid_synth_get_reverb_roomsize(self.synth)
     def get_reverb_damp(self):
@@ -478,12 +708,18 @@ class Synth:
         return fluid_synth_get_chorus_nr(self.synth)
     def get_chorus_level(self):
         return fluid_synth_get_reverb_level(self.synth)
-    def get_chorus_speed(self):
-        return fluid_synth_get_chorus_speed_Hz(self.synth)
-    def get_chorus_depth(self):
-        return fluid_synth_get_chorus_depth_ms(self.synth)
     def get_chorus_type(self):
         return fluid_synth_get_chorus_type(self.synth)
+    def get_chorus_speed(self):
+        try:
+            return fluid_synth_get_chorus_speed(self.synth)
+        except NameError:
+            return fluid_synth_get_chorus_speed_Hz(self.synth)
+    def get_chorus_depth(self):
+        try:
+            return fluid_synth_get_chorus_depth(self.synth)
+        except NameError:
+            return fluid_synth_get_chorus_depth_ms(self.synth)
     def noteon(self, chan, key, vel):
         """Play a note"""
         if key < 0 or key > 128:
@@ -492,7 +728,7 @@ class Synth:
             return False
         if vel < 0 or vel > 128:
             return False
-            return fluid_synth_noteon(self.synth, chan, key, vel)
+        return fluid_synth_noteon(self.synth, chan, key, vel)
     def noteoff(self, chan, key):
         """Stop a note"""
         if key < 0 or key > 128:
@@ -553,6 +789,79 @@ class Synth:
 
         """
         return fluid_synth_write_s16_stereo(self.synth, len)
+
+class Sequencer:
+    def __init__(self, time_scale=1000, use_system_timer=True):
+        """Create new sequencer object to control and schedule timing of midi events
+
+        Optional keyword arguments:
+        time_scale: ticks per second, defaults to 1000
+        use_system_timer: whether the sequencer should advance by itself
+        """
+        self.client_callbacks = []
+        self.sequencer = new_fluid_sequencer2(use_system_timer)
+        fluid_sequencer_set_time_scale(self.sequencer, time_scale)
+
+    def register_fluidsynth(self, synth):
+        response = fluid_sequencer_register_fluidsynth(self.sequencer, synth.synth)
+        if response == FLUID_FAILED:
+        	raise Error("Registering fluid synth failed")
+        return response
+
+    def register_client(self, name, callback, data=None):
+        c_callback = CFUNCTYPE(None, c_uint, c_void_p, c_void_p, c_void_p)(callback)
+        response = fluid_sequencer_register_client(self.sequencer, name.encode(), c_callback, data)
+        if response == FLUID_FAILED:
+        	raise Error("Registering client failed")
+
+        # store in a list to prevent garbage collection
+        self.client_callbacks.append(c_callback)
+
+        return response
+
+    def note(self, time, channel, key, velocity, duration, source=-1, dest=-1, absolute=True):
+        evt = self._create_event(source, dest)
+        fluid_event_note(evt, channel, key, velocity, duration)
+        self._schedule_event(evt, time, absolute)
+        delete_fluid_event(evt)
+
+    def note_on(self, time, channel, key, velocity=127, source=-1, dest=-1, absolute=True):
+        evt = self._create_event(source, dest)
+        fluid_event_noteon(evt, channel, key, velocity)
+        self._schedule_event(evt, time, absolute)
+        delete_fluid_event(evt)
+
+    def note_off(self, time, channel, key, source=-1, dest=-1, absolute=True):
+        evt = self._create_event(source, dest)
+        fluid_event_noteoff(evt, channel, key)
+        self._schedule_event(evt, time, absolute)
+        delete_fluid_event(evt)
+
+    def timer(self, time, data=None, source=-1, dest=-1, absolute=True):
+        evt = self._create_event(source, dest)
+        fluid_event_timer(evt, data)
+        self._schedule_event(evt, time, absolute)
+        delete_fluid_event(evt)
+
+    def _create_event(self, source=-1, dest=-1):
+        evt = new_fluid_event()
+        fluid_event_set_source(evt, source)
+        fluid_event_set_dest(evt, dest)
+        return evt
+
+    def _schedule_event(self, evt, time, absolute=True):
+        response = fluid_sequencer_send_at(self.sequencer, evt, time, absolute)
+        if response == FLUID_FAILED:
+            raise Error("Scheduling event failed")
+
+    def get_tick(self):
+        return fluid_sequencer_get_tick(self.sequencer)
+
+    def process(self, msec):
+        fluid_sequencer_process(self.sequencer, msec)
+
+    def delete(self):
+        delete_fluid_sequencer(self.sequencer)
 
 def raw_audio_string(data):
     """Return a string of bytes to send to soundcard

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup, Extension
 
 setup (name = 'pyFluidSynth',
-       version = '1.2.5',
+       version = '1.3',
        author = 'Nathan Whitehead',
        author_email = 'nwhitehe@gmail.com',
        url = 'https://github.com/nwhitehead/pyfluidsynth',


### PR DESCRIPTION
FluidSynth 2 made some changes to the API, outlined in the [dev docs](https://github.com/FluidSynth/fluidsynth/blob/8b1820580bdeddbfbc7f2a63f26db0b9d96f5b3c/doc/fluidsynth-v20-devdoc.txt).

TLDR `fluid_synth_set_midi_router` was deprecated, so the midi router has to be linked to the synth via `new_fluid_cmd_handler`, and chorus/reverb functions were renamed, hidden, exposed, etc. Try/except clauses are inserted so that pyfluidsynth should be able call the correct functions depending on which version of FluidSynth is being used without breaking any old code. 