### PR TITLE
Some extensive changes and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,124 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Geany project files
+*.geany
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,8 @@
+[settings]
+line_length = 99
+import_heading_stdlib = Standard library modules
+import_heading_localfolder = Application-specific modules
+import_heading_thirdparty = Third-party modules
+import_heading_firstparty = Organization-specific modules
+lines_before_imports = 1
+lines_after_imports = 2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,7 +42,7 @@
       * Added `RouterRule` class.
       * Added `router_add_rule` method of `Synth` class, which takes a
         `RouterRule` instance as argument.
-      * Removed `router_begin`, `router_end`, `router_chan`, `router_par1,
+      * Removed `router_begin`, `router_end`, `router_chan`, `router_par1`,
         `router_par2` methods from `Synth` class.
     * Updated list of available audio and MIDI drivers in code and documentation.
     * `Synth.start()` now raises `ValueError` if unknown driver name is passed.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,25 +1,65 @@
 ================================================================================
 
-    Jun 7-10, 2019
+    Jun 7-12, 2019 Christopher Arndt <info@chrisarndt.de>
 
-    + Bumped `api_version` to "2.0".
+    Enhancements & new features:
+
     * Integrated, fixed and enhanced fluidsynth 2 compatibility work done
       by Bill Peterson.
+    * Added support for support for fluidsynth MIDI player and renderer
+      and a new `Player` class for an object-oriented API to these.
     * Added support for `fluidsynth_settings_get*` functions.
     * Enhanced `Synth.settings` to act as a settings retrieval method as well.
-    * Replaced raising of undefined `Error` exception with `OSError`.
-    * Added `all_notes_off` support to `Synth` class.
-    * Explicitly import used names from cytpes module instead of star import
-      to enable checking for undefined names with code linters.
-    * Replaced use of `future` module for Python 2 compatibility with `six`.
+    * Added support for passing bool values to `Synth.setting`.
+    * Added support for passing bytes string values to `Synth.settings`.
+    * Added `all_notes_off` method to `Synth` class.
+    * Added `RouterRule` class (see below).
+    * Added MIDI router debug handler function bindings.
+    * Added tests scripts for fluidsynth MIDI file renderer.
+    * Described parameter names and types for most important functions and
+      methods with Sphinx-compatible syntax.
+    * Added module-level constants for fluid setting types (`FLUID_*_TYPE`),
+      MIDI router (`FLUID_MIDI_ROUTER_RULE_*` rule types, and MIDI player
+      state (`FLUID_PLAYER_*`).
+    * Added module-level constants `AUDIO_DRIVER_NAMES` and `MIDI_DRIVER_NAMES`
+      listing known audio and MIDI drivers.
+    * Added module-level constant `AUDIO_FILE_TYPES` listing known audio
+      file types for rendering.
+    * Added `.gitignore` file.
+    * Added configuration for `flake8`, `pylint' and `isort` QA tools.
+
+    Changes:
+
+    * Bumped `api_version` to "2.0".
+    * Updated copyright note at top of module source.
+    * Replaced use of `future` module for Python 2 compatibility with (simpler)
+      `six` module.
+    * Changed import of `ctypes` module to explicitly import used names instead
+      of star import to enable checking for undefined names with code linters.
+    * Changed `Synth.setting` to return result of `fluid_setting_set*` calls.
+    * Changed API to add MIDI router rules to be more object-oriented:
+
+      * Added `RouterRule` class.
+      * Added `router_add_rule` method of `Synth` class, which takes a
+        `RouterRule` instance as argument.
+      * Removed `router_begin`, `router_end`, `router_chan`, `router_par1,
+        `router_par2` methods from `Synth` class.
+    * Updated list of available audio and MIDI drivers in code and documentation.
+    * `Synth.start()` now raises `ValueError` if unknown driver name is passed.
     * Ordered function bindings by fluidsynth header file.
     * Re-ordered module level constants, functions and classes to be more
-      consistent and in accordacne with general practices.
+      consistent and in accordance with general Python best practices.
     * Re-formatted code for PEP-8 compliance, better consistency, no
       overlong lines and better separation of code blocks.
-    * Cleaned up docstrings formatting and punctuation.
     * Moved notes about changes from module docstring to this change log.
-      -- Christopher Arndt <info@chrisarndt.de>
+
+    Fixes:
+
+    * Replaced raising of undefined `Error` exception with `OSError`.
+    * Cleaned up docstrings formatting and punctuation.
+    * Made sure tests scripts find example soundfont when called from another
+      directory.
+    * Fixed Python 3 incompatibilities in test scripts.
 
 
 ================================================================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,15 +2,16 @@
 
     Jun 7-10, 2019
 
+    + Bumped `api_version` to "2.0".
     * Integrated, fixed and enhanced fluidsynth 2 compatibility work done
       by Bill Peterson.
-    * Added fluidsynth settings getter functions and enhanced `Synth.settings`
-      to act as a settings retrieval method as well.
+    * Added support for `fluidsynth_settings_get*` functions.
+    * Enhanced `Synth.settings` to act as a settings retrieval method as well.
     * Replaced raising of undefined `Error` exception with `OSError`.
-    * Add `all_notes_off` support to `Synth` class.
+    * Added `all_notes_off` support to `Synth` class.
     * Explicitly import used names from cytpes module instead of star import
       to enable checking for undefined names with code linters.
-    * Use `six` instead of `future` for Python 2 compatibility.
+    * Replaced use of `future` module for Python 2 compatibility with `six`.
     * Ordered function bindings by fluidsynth header file.
     * Re-ordered module level constants, functions and classes to be more
       consistent and in accordacne with general practices.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,50 @@
 ================================================================================
+
+    Jun 7-10, 2019
+
+    * Integrated, fixed and enhanced fluidsynth 2 compatibility work done
+      by Bill Peterson.
+    * Added fluidsynth settings getter functions and enhanced `Synth.settings`
+      to act as a settings retrieval method as well.
+    * Replaced raising of undefined `Error` exception with `OSError`.
+    * Add `all_notes_off` support to `Synth` class.
+    * Explicitly import used names from cytpes module instead of star import
+      to enable checking for undefined names with code linters.
+    * Use `six` instead of `future` for Python 2 compatibility.
+    * Ordered function bindings by fluidsynth header file.
+    * Re-ordered module level constants, functions and classes to be more
+      consistent and in accordacne with general practices.
+    * Re-formatted code for PEP-8 compliance, better consistency, no
+      overlong lines and better separation of code blocks.
+    * Cleaned up docstrings formatting and punctuation.
+    * Moved notes about changes from module docstring to this change log.
+      -- Christopher Arndt <info@chrisarndt.de>
+
+
+================================================================================
+
+    Jan 6, 2019
+
+    * Added fluidsynth 2 capability while maintaining backwards compatibility
+      -- Bill Peterson <albedozero@gmail.com>
+
+
+================================================================================
+
     May 24, 2018 - 1.2.5
-    
-    * Added sequencer support
+
+    * Added sequencer support -- Christian Romberg <distjubo@gmail.com>
+
+================================================================================
+
+    Jul 28, 2017
+
+    * Added lots of bindings and stuff to help with playing live
+      -- Bill Peterson <albedozero@gmail.com>
 
 
+================================================================================
 
- ================================================================================
     February 13, 2015
 
     * Mover repository to git in GitHub
@@ -15,61 +54,61 @@
 
 ================================================================================
 
-	March 2, 2009 - 1.2.4
+    March 2, 2009 - 1.2.4
 
-	* Another attempt to find the proper library on Windows systems. Added 
-	short circuited or expression to find either 'fluidsynth' or 
-	'libfluidsynth'.
-	* Only import numpy when it's actually needed.
+    * Another attempt to find the proper library on Windows systems. Added
+    short circuited or expression to find either 'fluidsynth' or
+    'libfluidsynth'.
+    * Only import numpy when it's actually needed.
+
+
+================================================================================
+
+    January 15, 2009 - 1.2.3
+
+    * Throw ImportError if the fluidsynth library can't be found.
+    * Range checking in noteon and noteoff
 
 
 ================================================================================
 
-	January 15, 2009 - 1.2.3
+    January 15, 2009 - 1.2.2
 
-	* Throw ImportError if the fluidsynth library can't be found.
-	* Range checking in noteon and noteoff
+    * Small version increment to update website and maintainer info.
+      No actual code changes.
 
- 
-================================================================================
-
-	January 15, 2009 - 1.2.2
-
-	* Small version increment to update website and maintainer info. 
-	  No actual code changes.
-
- 
-================================================================================
-
-	July 22, 2008 - 1.2.1
-
-	* Added pydoc documentation and this CHANGELOG.
- 
 
 ================================================================================
 
-	July 22, 2008 - 1.2
+    July 22, 2008 - 1.2.1
 
-	* Changed from C extension code to ctypes for portability and simplicity
-	  of code.
+    * Added pydoc documentation and this CHANGELOG.
 
-	* Updated interface to use objects instead of just functions.
 
- 
 ================================================================================
 
-	July 21, 2008 - 1.1
+    July 22, 2008 - 1.2
 
-	* Added direct audio data interface so you don't have to start audio
-	  driver thread.  Makes pyFluidSynth work for audio games and other
-	  applications that manage their own sound.
+    * Changed from C extension code to ctypes for portability and simplicity
+      of code.
 
- 
+    * Updated interface to use objects instead of just functions.
+
+
 ================================================================================
 
-	July 16, 2008 - 1.0
+    July 21, 2008 - 1.1
 
-	* Imported from previous work done earlier in the summer.
+    * Added direct audio data interface so you don't have to start audio
+      driver thread.  Makes pyFluidSynth work for audio games and other
+      applications that manage their own sound.
+
+
+================================================================================
+
+    July 16, 2008 - 1.0
+
+    * Imported from previous work done earlier in the summer.
 
 
 ================================================================================

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <em>Python bindings for FluidSynth</em>
 
+**NOTE:** *This unofficial fork is now unamaintained and the repository archived!*
+
 This module contains python bindings for FluidSynth.  FluidSynth is a
 software synthesizer for generating music.  It works like a MIDI
 synthesizer.  You load patches, set parameters, then send NOTEON and

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -490,6 +490,20 @@ fluid_midi_router_handle_midi_event = cfunc(
     c_int,
     ('data', c_void_p, 1),
     ('event', c_void_p, 1))
+fluid_midi_router_clear_rules = cfunc(
+    'fluid_midi_router_clear_rules',
+    c_int,
+    ('router', POINTER(fluid_midi_router_t), 1))
+fluid_midi_router_set_default_rules = cfunc(
+    'fluid_midi_router_set_default_rules',
+    c_int,
+    ('router', POINTER(fluid_midi_router_t), 1))
+fluid_midi_router_add_rule = cfunc(
+    'fluid_midi_router_add_rule',
+    c_int,
+    ('router', POINTER(fluid_midi_router_t), 1),
+    ('rule', c_void_p, 1),
+    ('type', c_int, 1))
 
 # fluid midi router rules
 new_fluid_midi_router_rule = cfunc(
@@ -519,20 +533,6 @@ fluid_midi_router_rule_set_param2 = cfunc(
     ('max', c_int, 1),
     ('mul', c_float, 1),
     ('add', c_int, 1))
-fluid_midi_router_clear_rules = cfunc(
-    'fluid_midi_router_clear_rules',
-    c_int,
-    ('router', POINTER(fluid_midi_router_t), 1))
-fluid_midi_router_set_default_rules = cfunc(
-    'fluid_midi_router_set_default_rules',
-    c_int,
-    ('router', POINTER(fluid_midi_router_t), 1))
-fluid_midi_router_add_rule = cfunc(
-    'fluid_midi_router_add_rule',
-    c_int,
-    ('router', POINTER(fluid_midi_router_t), 1),
-    ('rule', c_void_p, 1),
-    ('type', c_int, 1))
 delete_fluid_midi_router_rule = cfunc(
     'delete_fluid_midi_router_rule',
     c_int,

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -490,6 +490,16 @@ fluid_midi_router_handle_midi_event = cfunc(
     c_int,
     ('data', c_void_p, 1),
     ('event', c_void_p, 1))
+fluid_midi_dump_prerouter = cfunc(
+    'fluid_midi_dump_prerouter',
+    c_int,
+    ('data', c_void_p, 1),
+    ('event', c_void_p, 1))
+fluid_midi_dump_postrouter = cfunc(
+    'fluid_midi_dump_postrouter',
+    c_int,
+    ('data', c_void_p, 1),
+    ('event', c_void_p, 1))
 fluid_midi_router_clear_rules = cfunc(
     'fluid_midi_router_clear_rules',
     c_int,

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -452,6 +452,10 @@ new_fluid_midi_driver = cfunc(
     ('settings', c_void_p, 1),
     ('handler', CFUNCTYPE(POINTER(c_int), c_void_p, c_void_p), 1),
     ('event_handler_data', c_void_p, 1))
+delete_fluid_midi_driver = cfunc(
+    'delete_fluid_midi_driver',
+    None,
+    ('driver', c_void_p, 1))
 
 
 # fluid midi router
@@ -822,6 +826,9 @@ class Synth:
     def delete(self):
         if self.audio_driver is not None:
             delete_fluid_audio_driver(self.audio_driver)
+
+        if self.midi_driver is not None:
+            delete_fluid_midi_driver(self.midi_driver)
 
         delete_fluid_synth(self.synth)
         delete_fluid_settings(self.settings)

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -504,6 +504,10 @@ fluid_midi_router_add_rule = cfunc(
     ('router', POINTER(fluid_midi_router_t), 1),
     ('rule', c_void_p, 1),
     ('type', c_int, 1))
+delete_fluid_midi_router = cfunc(
+    'delete_fluid_midi_router',
+    c_int,
+    ('router', POINTER(fluid_midi_router_t), 1))
 
 # fluid midi router rules
 new_fluid_midi_router_rule = cfunc(
@@ -876,6 +880,9 @@ class Synth:
 
         if self.midi_driver is not None:
             delete_fluid_midi_driver(self.midi_driver)
+
+        if self.router is not None:
+            delete_fluid_midi_router(self.router)
 
         delete_fluid_synth(self.synth)
         delete_fluid_settings(self.settings)

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -23,7 +23,9 @@
 
 """
 
-from ctypes import *
+# Standard library modules
+from ctypes import (CDLL, CFUNCTYPE, POINTER, Structure, byref, c_char, c_char_p, c_double,
+                    c_float, c_int, c_short, c_uint, c_void_p, create_string_buffer)
 from ctypes.util import find_library
 from future.utils import iteritems
 

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -32,6 +32,12 @@ from ctypes.util import find_library
 from six import binary_type, iteritems, text_type
 
 
+# Bump this up when changing the interface for users
+api_version = '1.3'
+# Function call result
+FLUID_OK = 0
+FLUID_FAILED = -1
+
 # A short circuited or expression to find the FluidSynth library
 # (mostly needed for Windows distributions of libfluidsynth supplied with QSynth)
 
@@ -586,6 +592,17 @@ def fluid_synth_write_s16_stereo(synth, len):
     return numpy.frombuffer(buf[:], dtype=numpy.int16)
 
 
+def raw_audio_string(data):
+    """Return a string of bytes to send to soundcard.
+
+    Input is a numpy array of samples.  Default output format
+    is 16-bit signed (other formats not currently supported).
+
+    """
+    import numpy
+    return (data.astype(numpy.int16)).tostring()
+
+
 # Object-oriented interface, simplifies access to functions
 
 class Synth:
@@ -985,14 +1002,3 @@ class Sequencer:
 
     def delete(self):
         delete_fluid_sequencer(self.sequencer)
-
-
-def raw_audio_string(data):
-    """Return a string of bytes to send to soundcard
-
-    Input is a numpy array of samples.  Default output format
-    is 16-bit signed (other formats not currently supported).
-
-    """
-    import numpy
-    return (data.astype(numpy.int16)).tostring()

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -1003,7 +1003,8 @@ class Sequencer:
         response = fluid_sequencer_register_fluidsynth(self.sequencer, synth.synth)
 
         if response == FLUID_FAILED:
-            raise Error("Registering fluid synth failed")
+            raise OSError("Registering fluid synth failed")
+
         return response
 
     def register_client(self, name, callback, data=None):
@@ -1011,7 +1012,7 @@ class Sequencer:
         response = fluid_sequencer_register_client(self.sequencer, name.encode(), c_callback, data)
 
         if response == FLUID_FAILED:
-            raise Error("Registering client failed")
+            raise OSError("Registering client failed")
 
         # store in a list to prevent garbage collection
         self.client_callbacks.append(c_callback)
@@ -1051,7 +1052,7 @@ class Sequencer:
         response = fluid_sequencer_send_at(self.sequencer, evt, time, absolute)
 
         if response == FLUID_FAILED:
-            raise Error("Scheduling event failed")
+            raise OSError("Scheduling event failed")
 
     def get_tick(self):
         return fluid_sequencer_get_tick(self.sequencer)

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -628,42 +628,6 @@ delete_fluid_sequencer = cfunc(
     'delete_fluid_sequencer',
     None,
     ('seq', c_void_p, 1))
-fluid_sequencer_register_fluidsynth = cfunc(
-    'fluid_sequencer_register_fluidsynth',
-    c_short,
-    ('seq', c_void_p, 1),
-    ('synth', c_void_p, 1))
-fluid_sequencer_register_client = cfunc(
-    'fluid_sequencer_register_client',
-    c_short,
-    ('seq', c_void_p, 1),
-    ('name', c_char_p, 1),
-    ('callback', CFUNCTYPE(None, c_uint, c_void_p, c_void_p, c_void_p), 1),
-    ('data', c_void_p, 1))
-fluid_sequencer_get_tick = cfunc(
-    'fluid_sequencer_get_tick',
-    c_uint,
-    ('seq', c_void_p, 1))
-fluid_sequencer_set_time_scale = cfunc(
-    'fluid_sequencer_set_time_scale',
-    None,
-    ('seq', c_void_p, 1),
-    ('scale', c_double, 1))
-fluid_sequencer_get_time_scale = cfunc(
-    'fluid_sequencer_get_time_scale',
-    c_double,
-    ('seq', c_void_p, 1))
-fluid_sequencer_send_at = cfunc(
-    'fluid_sequencer_send_at',
-    c_int,
-    ('seq', c_void_p, 1),
-    ('evt', c_void_p, 1),
-    ('time', c_uint, 1),
-    ('absolute', c_int, 1))
-delete_fluid_sequencer = cfunc(
-    'delete_fluid_sequencer',
-    None,
-    ('seq', c_void_p, 1))
 
 # fluid event
 new_fluid_event = cfunc(

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -53,6 +53,10 @@ FLUID_MIDI_ROUTER_RULE_PROG_CHANGE = 2       # MIDI program change rule
 FLUID_MIDI_ROUTER_RULE_PITCH_BEND = 3        # MIDI pitch bend rule
 FLUID_MIDI_ROUTER_RULE_CHANNEL_PRESSURE = 4  # MIDI channel pressure rule
 FLUID_MIDI_ROUTER_RULE_KEY_PRESSURE = 5      # MIDI key pressure rule
+# Driver names
+AUDIO_DRIVER_NAMES = ("alsa, coreaudio, dart, dsound, file, jack, oss, portaudio, pulseaudio, "
+                      "sdl2, sndman, waveout").split(", ")
+MIDI_DRIVER_NAMES = "alsa_raw, alsa_seq, coremidi, jack, midishare, oss, winmidi".split(", ")
 
 # A short circuited or expression to find the FluidSynth library
 # (mostly needed for Windows distributions of libfluidsynth supplied with QSynth)
@@ -827,25 +831,43 @@ class Synth:
     def start(self, driver=None, device=None, midi_driver=None, cmd_handler=False):
         """Start audio output driver in separate background thread.
 
-        Call this function any time after creating the Synth object.
-        If you don't call this function, use get_samples() to generate
+        Call this function any time after creating the Synth object to start
+        handling events.
+
+        If you don't call this function, use ``get_samples()`` to generate
         samples.
 
-        Optional keyword argument:
-        driver : which audio driver to use for output
-        Possible choices:
-        'alsa', 'oss', 'jack', 'portaudio'
-        'sndmgr', 'coreaudio', 'Direct Sound'
-        device: the device to use for audio output
+        Optional keyword arguments:
 
-        Not all drivers will be available for every platform, it
-        depends on which drivers were compiled into FluidSynth for
-        your platform.
+        :param driver: which audio driver to use for output
+        :type driver: str
+        :param device: the device to use for audio output
+        :type device: str
+        :param midi_driver: which driver to use for MIDI input
+        :type midi_driver: str
+        :param cmd_handler: whether to create a shell command handler
+        :type cmd_handler: bool (default: ``False``)
+
+        Possible choices for ``driver`` are:
+
+        alsa, coreaudio, dart, dsound, file, jack, oss, portaudio, pulseaudio,
+        sdl2, sndman, waveout
+
+        See also: http://www.fluidsynth.org/api/fluidsettings.xml#audio.driver
+
+        Possible choices for ``midi_driver`` are:
+
+        alsa_raw, alsa_seq, coremidi, jack, midishare, oss, winmidi
+
+        See also: http://www.fluidsynth.org/api/fluidsettings.xml#midi.driver
+
+        Not all drivers will be available for every platform, it depends on
+        which drivers were compiled into FluidSynth for your platform.
 
         """
         if driver is not None:
-            assert driver in ['alsa', 'oss', 'jack', 'portaudio', 'sndmgr', 'coreaudio',
-                              'Direct Sound', 'pulseaudio']
+            if driver not in AUDIO_DRIVER_NAMES:
+                raise ValueError("Unknown audio driver '%'." % driver)
             self.setting('audio.driver', driver)
 
             if device is not None:
@@ -854,8 +876,8 @@ class Synth:
             self.audio_driver = new_fluid_audio_driver(self.settings, self.synth)
 
         if midi_driver is not None:
-            assert midi_driver in ['alsa_seq', 'alsa_raw', 'oss', 'winmidi', 'midishare',
-                                   'coremidi']
+            if midi_driver not in MIDI_DRIVER_NAMES:
+                raise ValueError("Unknown MIDI driver '%'." % midi_driver)
             self.setting('midi.driver', midi_driver)
             self.router = new_fluid_midi_router(self.settings, fluid_synth_handle_midi_event,
                                                 self.synth)

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -27,13 +27,10 @@
 from ctypes import (CDLL, CFUNCTYPE, POINTER, Structure, byref, c_char, c_char_p, c_double,
                     c_float, c_int, c_short, c_uint, c_void_p, create_string_buffer)
 from ctypes.util import find_library
-from future.utils import iteritems
 
-# Python2-3 compatibility hack
-try:
-    basestring
-except NameError:
-    basestring = str
+# Third-party modules
+from six import binary_type, iteritems, text_type
+
 
 # A short circuited or expression to find the FluidSynth library
 # (mostly needed for Windows distributions of libfluidsynth supplied with QSynth)
@@ -614,7 +611,9 @@ class Synth:
     def setting(self, opt, val):
         """change an arbitrary synth setting, type-smart"""
         opt = opt.encode()
-        if isinstance(val, basestring):
+        if isinstance(val, text_type):
+            fluid_settings_setstr(self.settings, opt, val.encode())
+        elif isinstance(val, binary_type):
             fluid_settings_setstr(self.settings, opt, val)
         elif isinstance(val, int):
             fluid_settings_setint(self.settings, opt, val)

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -483,7 +483,7 @@ new_fluid_midi_router = cfunc(
     'new_fluid_midi_router',
     POINTER(fluid_midi_router_t),
     ('settings', c_void_p, 1),
-    ('handler', CFUNCTYPE(POINTER(c_int), c_void_p, c_void_p), 1),
+    ('handler', CFUNCTYPE(c_int, c_void_p, c_void_p), 1),
     ('event_handler_data', c_void_p, 1))
 fluid_midi_router_handle_midi_event = cfunc(
     'fluid_midi_router_handle_midi_event',

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -900,14 +900,14 @@ class Sequencer:
     def register_fluidsynth(self, synth):
         response = fluid_sequencer_register_fluidsynth(self.sequencer, synth.synth)
         if response == FLUID_FAILED:
-        	raise Error("Registering fluid synth failed")
+            raise Error("Registering fluid synth failed")
         return response
 
     def register_client(self, name, callback, data=None):
         c_callback = CFUNCTYPE(None, c_uint, c_void_p, c_void_p, c_void_p)(callback)
         response = fluid_sequencer_register_client(self.sequencer, name.encode(), c_callback, data)
         if response == FLUID_FAILED:
-        	raise Error("Registering client failed")
+            raise Error("Registering client failed")
 
         # store in a list to prevent garbage collection
         self.client_callbacks.append(c_callback)

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -1162,18 +1162,19 @@ class Synth:
                 response = fluid_settings_copystr(self.settings, opt, data, 256)
                 return _d(data.value) if response == FLUID_OK else None
             elif stype == FLUID_SET_TYPE:
-                raise NotImplementedError("Getting a setting value of type FLUID_SET_TYPE is not "
-                                          "supported yet.")
+                raise NotImplementedError("Setting of type FLUID_SET_TYPE not implemented.")
             elif stype == FLUID_NO_TYPE:
                 raise KeyError("Setting '%s' does not exist." % _d(opt))
         elif isinstance(val, text_type):
-            fluid_settings_setstr(self.settings, opt, _e(val))
+            return fluid_settings_setstr(self.settings, opt, _e(val))
         elif isinstance(val, binary_type):
-            fluid_settings_setstr(self.settings, opt, val)
+            return fluid_settings_setstr(self.settings, opt, val)
+        elif isinstance(val, bool):
+            return fluid_settings_setint(self.settings, opt, 1 if val else 0)
         elif isinstance(val, int):
-            fluid_settings_setint(self.settings, opt, val)
+            return fluid_settings_setint(self.settings, opt, val)
         elif isinstance(val, float):
-            fluid_settings_setnum(self.settings, opt, val)
+            return fluid_settings_setnum(self.settings, opt, val)
 
     def start(self, driver=None, device=None, midi_driver=None, cmd_handler=False):
         """Start audio output driver in separate background thread.

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -21,9 +21,6 @@
 
 ================================================================================
 
-Added lots of bindings and stuff to help with playing live -- Bill Peterson <albedozero@gmail.com>
-Added sequencer support -- Christian Romberg <distjubo@gmail.com>
-Tried to build in fluidsynth 2 capability while maintaining backwards compatibility -- Bill Peterson <albedozero@gmail.com>
 """
 
 from ctypes import *

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -71,6 +71,11 @@ FLUID_FAILED = -1
 # fluid settings
 new_fluid_settings = cfunc('new_fluid_settings', c_void_p)
 
+fluid_settings_getint = cfunc('fluid_settings_getint', c_int,
+                              ('settings', c_void_p, 1),
+                              ('name', c_char_p, 1),
+                              ('val', POINTER(c_int), 1))
+
 fluid_settings_setstr = cfunc('fluid_settings_setstr', c_int,
                               ('settings', c_void_p, 1),
                               ('name', c_char_p, 1),
@@ -617,6 +622,11 @@ class Synth:
             fluid_settings_setint(self.settings, opt, val)
         elif isinstance(val, float):
             fluid_settings_setnum(self.settings, opt, val)
+    def settings_getint(self, opt):
+        opt = opt.encode()
+        val = c_int()
+        res = fluid_settings_getint(self.settings, opt, val)
+        return val.value if res != 0 else None
     def start(self, driver=None, device=None, midi_driver=None):
         """Start audio output driver in separate background thread
 

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -819,8 +819,8 @@ def fluid_synth_write_s16_stereo(synth, nframes):
 def raw_audio_string(data):
     """Return a string of bytes to send to soundcard.
 
-    Input is a numpy array of samples.  Default output format
-    is 16-bit signed (other formats not currently supported).
+    Input is a numpy array of samples. Default output format is 16-bit signed
+    (other formats not currently supported).
 
     """
     import numpy
@@ -1026,7 +1026,7 @@ class Player(BasePlayer):
             ``flac`` or ``oga``
         :type quality: ``float`` (0.0 - 1.0)
         :param progress_callback: Python callable to call after each
-            period-size block of samples has been written. Receives the
+            period-size block of sample frames has been written. Receives the
             filename, filetype, current total number of sample frames written
             and the period size as positional arguments in that order.
         :type progress_callback: callable with 4 positional args
@@ -1074,7 +1074,7 @@ class Player(BasePlayer):
         Internal method called by ``Player.render()``.
 
         :param filename: audio output file path and name
-        'type filename: ``str``
+        :type filename: ``str``
         :param filetype: audio output file type
         :type filetype: ``str``
 
@@ -1126,10 +1126,28 @@ class Synth:
         """Create new synthesizer object to control sound generation.
 
         Optional keyword arguments:
-        gain : scale factor for audio output, default is 0.2
-        lower values are quieter, allow more simultaneous notes
-        samplerate : output samplerate in Hz, default is 44100 Hz
-        added capability for passing arbitrary fluid settings using args
+
+        :param gain: scale factor for audio output, default is 0.2. lower
+            values give quieter output and allow more simultaneous notes
+            without clipping
+        :type gain: ``float``
+        :param samplerate: output samplerate in Hz, default is 44100.0 Hz
+            added capability for passing arbitrary fluid settings using args
+        :type samplerate: ``float``
+        :param channels: the number of MIDI channels the synthesizer supports.
+            MIDI hardware is limited to 16 channels (the default value, but
+            internally FluidSynth can use up to 256 channels, which can be
+            mapped to different MIDI sources.
+        :type channels: ``int``
+
+        Additional keyword arguments are interpreted and applied as fluidsynth
+        settings, i.e. the argument name is used as the setting name and its
+        value as the setting value. Since most fluidsynth setting names are not
+        valid Python identifiers and therefor can not be used keyword arguments
+        directly, you have to pass them via the ``**kwarg`` syntax. The values
+        must have the proper type, i.e. ``int`` for ``FLUID_INT_TYPE` settings,
+        `'float`` for ``FLUID_NUM_TYPE`` and ``str``  or ``bytes`` for
+        ``FLUID_STR_TYPE`` settings.
 
         """
         self.settings = new_fluid_settings()
@@ -1192,13 +1210,13 @@ class Synth:
         Optional keyword arguments:
 
         :param driver: which audio driver to use for output
-        :type driver: str
+        :type driver: ``str``
         :param device: the device to use for audio output
-        :type device: str
+        :type device: ``str``
         :param midi_driver: which driver to use for MIDI input
-        :type midi_driver: str
+        :type midi_driver: ``str``
         :param cmd_handler: whether to create a shell command handler
-        :type cmd_handler: bool (default: ``False``)
+        :type cmd_handler: ``bool`` (default: ``False``)
 
         Possible choices for ``driver`` are:
 
@@ -1329,10 +1347,14 @@ class Synth:
     def set_reverb(self, roomsize=-1.0, damping=-1.0, width=-1.0, level=-1.0):
         """Set reverb parameters.
 
-        roomsize: Reverb room size value (0.0-1.0)
-        damping: Reverb damping value (0.0-1.0)
-        width: Reverb width value (0.0-100.0)
-        level: Reverb level value (0.0-1.0)
+        :param roomsize: Reverb room size value (0.0-1.0)
+        :type roomsize: ``float``
+        :param damping: Reverb damping value (0.0-1.0)
+        :type damping: ``float``
+        :param width: Reverb width value (0.0-100.0)
+        :type width: ``float``
+        :param level: Reverb level value (0.0-1.0)
+        :type level: ``float``
 
         """
         if fluid_synth_set_reverb:
@@ -1354,12 +1376,18 @@ class Synth:
     def set_chorus(self, nr=-1, level=-1.0, speed=-1.0, depth=-1.0, type=-1):
         """Set chorus parameters.
 
-        nr: Chorus voice count (0-99, CPU time consumption proportional to this value)
-        level: Chorus level (0.0-10.0)
-        speed: Chorus speed in Hz (0.29-5.0)
-        depth: Chorus depth (max value depends on synth sample rate,
-               0.0-21.0 is safe for sample rate values up to 96KHz)
-        type: Chorus waveform type (0=sine, 1=triangle)
+        :param nr: Chorus voice count (0-99, CPU time consumption proportional
+            to this value)
+        :type nr: ``int``
+        :param level: Chorus level (0.0-10.0)
+        :type levl: ``float``
+        :param speed: Chorus speed in Hz (0.29-5.0)
+        :type speed: ``float``
+        :param depth: Chorus depth (max value depends on synth sample rate,
+           0.0-21.0 is safe for sample rate values up to 96KHz)
+        :type depth: ``float``
+        :param type: Chorus waveform type (0=sine, 1=triangle)
+        :type type: ``int``
 
         """
         if fluid_synth_set_chorus:
@@ -1530,8 +1558,8 @@ class Sequencer:
 
         Optional keyword arguments:
 
-        time_scale: ticks per second, defaults to 1000
-        use_system_timer: whether the sequencer should advance by itself
+        :param time_scale: ticks per second, defaults to 1000
+        :param use_system_timer: whether the sequencer should advance by itself
 
         """
         self.client_callbacks = []

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -177,6 +177,10 @@ fluid_synth_program_reset = cfunc('fluid_synth_program_reset', c_int,
 fluid_synth_system_reset = cfunc('fluid_synth_system_reset', c_int,
                                   ('synth', c_void_p, 1))
 
+fluid_synth_all_notes_off = cfunc('fluid_synth_all_notes_off', c_int,
+                                  ('synth', c_void_p, 1),
+                                  ('chan', c_int, 1))
+
 fluid_synth_write_s16 = cfunc('fluid_synth_write_s16', c_void_p,
                               ('synth', c_void_p, 1),
                               ('len', c_int, 1),
@@ -874,6 +878,9 @@ class Synth:
     def system_reset(self):
         """Stop all notes and reset all programs"""
         return fluid_synth_system_reset(self.synth)
+    def all_notes_off(self, chan):
+        """Turn off all notes on a MIDI channel (put them into release phase)."""
+        return fluid_synth_all_notes_off(self.synth, chan)
     def get_samples(self, len=1024):
         """Generate audio samples
 

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -258,7 +258,7 @@ fluid_synth_write_s16 = cfunc(
     ('rincr', c_int, 1))
 fluid_synth_handle_midi_event = cfunc(
     'fluid_synth_handle_midi_event',
-    POINTER(c_int),
+    c_int,
     ('data', c_void_p, 1),
     ('event', c_void_p, 1))
 

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -487,7 +487,7 @@ new_fluid_midi_router = cfunc(
     ('event_handler_data', c_void_p, 1))
 fluid_midi_router_handle_midi_event = cfunc(
     'fluid_midi_router_handle_midi_event',
-    POINTER(c_int),
+    c_int,
     ('data', c_void_p, 1),
     ('event', c_void_p, 1))
 

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -602,14 +602,13 @@ class Synth:
         samplerate : output samplerate in Hz, default is 44100 Hz
         added capability for passing arbitrary fluid settings using args
         """
-        st = new_fluid_settings()
-        fluid_settings_setnum(st, b'synth.gain', gain)
-        fluid_settings_setnum(st, b'synth.sample-rate', samplerate)
-        fluid_settings_setint(st, b'synth.midi-channels', channels)
-        for opt,val in iteritems(kwargs):
+        self.settings = new_fluid_settings()
+        fluid_settings_setnum(self.settings, b'synth.gain', gain)
+        fluid_settings_setnum(self.settings, b'synth.sample-rate', samplerate)
+        fluid_settings_setint(self.settings, b'synth.midi-channels', channels)
+        for opt, val in iteritems(kwargs):
             self.setting(opt, val)
-        self.settings = st
-        self.synth = new_fluid_synth(st)
+        self.synth = new_fluid_synth(self.settings)
         self.audio_driver = None
         self.midi_driver = None
         self.router = None

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -31,7 +31,7 @@ from ctypes.util import find_library
 # Third-party modules
 from six import binary_type, iteritems, text_type
 
-# constants
+# Constants
 
 # Bump this up when changing the interface for users
 api_version = '2.0'
@@ -91,7 +91,7 @@ def cfunc(name, result, *args):
 
 # Function prototypes for C versions of functions
 
-# fluid settings
+# Fluid settings
 new_fluid_settings = cfunc(
     'new_fluid_settings',
     c_void_p)
@@ -142,7 +142,7 @@ delete_fluid_settings = cfunc(
     None,
     ('settings', c_void_p, 1))
 
-# fluid synth
+# Fluid synth
 new_fluid_synth = cfunc(
     'new_fluid_synth',
     c_void_p,
@@ -151,7 +151,7 @@ delete_fluid_synth = cfunc(
     'delete_fluid_synth',
     None,
     ('synth', c_void_p, 1))
-# soundfont handling
+# Soundfont handling
 fluid_synth_sfload = cfunc(
     'fluid_synth_sfload',
     c_int,
@@ -248,7 +248,7 @@ fluid_synth_all_notes_off = cfunc(
     c_int,
     ('synth', c_void_p, 1),
     ('chan', c_int, 1))
-# reset functions
+# Reset functions
 fluid_synth_program_reset = cfunc(
     'fluid_synth_program_reset',
     c_int,
@@ -257,7 +257,7 @@ fluid_synth_system_reset = cfunc(
     'fluid_synth_system_reset',
     c_int,
     ('synth', c_void_p, 1))
-# misc
+# Misc
 fluid_synth_write_s16 = cfunc(
     'fluid_synth_write_s16',
     c_void_p,
@@ -275,7 +275,7 @@ fluid_synth_handle_midi_event = cfunc(
     ('data', c_void_p, 1),
     ('event', c_void_p, 1))
 
-# reverb
+# Reverb
 fluid_synth_get_reverb_roomsize = cfunc(
     'fluid_synth_get_reverb_roomsize',
     c_double,
@@ -342,7 +342,7 @@ except AttributeError:
     fluid_synth_set_reverb_level = None
     fluid_synth_set_reverb_width = None
 
-# chorus
+# Chorus
 fluid_synth_get_chorus_nr = cfunc(
     'fluid_synth_get_chorus_nr',
     c_int,
@@ -454,7 +454,7 @@ except AttributeError:
     fluid_synth_get_channel_info = None
     del fluid_synth_channel_info_t
 
-# fluid audio driver
+# Fluid audio driver
 new_fluid_audio_driver = cfunc(
     'new_fluid_audio_driver',
     c_void_p,
@@ -465,7 +465,7 @@ delete_fluid_audio_driver = cfunc(
     None,
     ('driver', c_void_p, 1))
 
-# fluid midi driver
+# Fluid MIDI driver
 new_fluid_midi_driver = cfunc(
     'new_fluid_midi_driver',
     c_void_p,
@@ -478,7 +478,7 @@ delete_fluid_midi_driver = cfunc(
     ('driver', c_void_p, 1))
 
 
-# fluid midi router
+# Fluid MIDI router
 class fluid_midi_router_t(Structure):
     _fields_ = [
         ('synth', c_void_p),
@@ -532,7 +532,7 @@ delete_fluid_midi_router = cfunc(
     c_int,
     ('router', POINTER(fluid_midi_router_t), 1))
 
-# fluid midi router rules
+# Fluid MIDI router rules
 new_fluid_midi_router_rule = cfunc(
     'new_fluid_midi_router_rule',
     c_void_p)
@@ -565,7 +565,7 @@ delete_fluid_midi_router_rule = cfunc(
     c_int,
     ('rule', c_void_p, 1))
 
-# command handler
+# Command handler
 try:
     new_fluid_cmd_handler = cfunc(
         'new_fluid_cmd_handler',
@@ -583,7 +583,7 @@ delete_fluid_cmd_handler = cfunc(
         c_void_p,
         ('handler', c_void_p, 1))
 
-# preset handling
+# Preset handling
 try:
     fluid_preset_get_name = cfunc(
         'fluid_preset_get_name',
@@ -599,7 +599,7 @@ except AttributeError:
     fluid_preset_get_name = None
     fluid_sfont_get_preset = None
 
-# fluid file renderer
+# Fluid file renderer
 new_fluid_file_renderer = cfunc(
     'new_fluid_file_renderer',
     c_void_p,
@@ -618,7 +618,7 @@ delete_fluid_file_renderer = cfunc(
     c_void_p,
     ('dev', c_void_p, 1))
 
-# fluid midi player
+# Fluid MIDI player
 new_fluid_player = cfunc(
     'new_fluid_player',
     c_void_p,
@@ -691,7 +691,7 @@ delete_fluid_player = cfunc(
     c_void_p,
     ('player', c_void_p, 1))
 
-# fluid sequencer
+# Fluid sequencer
 new_fluid_sequencer2 = cfunc(
     'new_fluid_sequencer2',
     c_void_p,
@@ -738,7 +738,7 @@ delete_fluid_sequencer = cfunc(
     None,
     ('seq', c_void_p, 1))
 
-# fluid event
+# Fluid events
 new_fluid_event = cfunc(
     'new_fluid_event',
     c_void_p)
@@ -798,7 +798,7 @@ def _e(s, encoding=DEFAULT_ENCODING):
     return s
 
 
-# convenience functions
+# Convenience functions
 
 def fluid_synth_write_s16_stereo(synth, nframes):
     """Return generated samples in stereo 16-bit format.
@@ -1050,14 +1050,13 @@ class Player(BasePlayer):
 
         try:
             while self.status != FLUID_PLAYER_DONE:
-                # render one block
+                # Render one block
                 if fluid_file_renderer_process_block(renderer) != FLUID_OK:
                     raise OSError('MIDI file renderer error.')
 
-                # increment with period size
                 num_samples += period_size
                 if progress_callback:
-                    # for progress reporting
+                    # For progress reporting
                     progress_callback(filename, filetype, num_samples, period_size)
         finally:
             self.stop()
@@ -1581,7 +1580,7 @@ class Sequencer:
         if response == FLUID_FAILED:
             raise OSError("Registering client failed")
 
-        # store in a list to prevent garbage collection
+        # Store in a list to prevent garbage collection
         self.client_callbacks.append(c_callback)
         return response
 

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -5,7 +5,7 @@
 
     Python bindings for FluidSynth
 
-    Copyright 2008, Nathan Whitehead <nwhitehe@gmail.com>
+    Copyright 2008-2019, Nathan Whitehead <nwhitehe@gmail.com> and others
 
 
     Released under the LGPL

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -800,15 +800,19 @@ def _e(s, encoding=DEFAULT_ENCODING):
 
 # convenience functions
 
-def fluid_synth_write_s16_stereo(synth, len):
+def fluid_synth_write_s16_stereo(synth, nframes):
     """Return generated samples in stereo 16-bit format.
 
-    Return value is a Numpy array of samples.
+    :param synth: an instance of class Synth
+    :param nframes: number of sample frames to generate
+    :type nframes: ``int``
+    :return: one-dimenional NumPy array of interleaved samples
+    :rtype: ``np.array(..., dtype=numpy.int16)``
 
     """
     import numpy
-    buf = create_string_buffer(len * 4)
-    fluid_synth_write_s16(synth, len, buf, 0, 2, buf, 1, 2)
+    buf = create_string_buffer(nframes * 4)
+    fluid_synth_write_s16(synth, nframes, buf, 0, 2, buf, 1, 2)
     return numpy.frombuffer(buf[:], dtype=numpy.int16)
 
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,2 @@
+[MESSAGE CONTROL]
+disable=invalid-name,missing-docstring

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length: 100

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,27 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+"""\
+Python bindings for FluidSynth, a MIDI synthesizer using SoundFont instruments.
+
+FluidSynth is a software synthesizer for generating music.  It works like a
+MIDI synthesizer.  You load patches, set parameters, then send NOTEON and
+NOTEOFF events to play notes.  Instruments are defined in SoundFonts,
+generally files with the extension SF2.  FluidSynth can either be used to play
+audio itself, or you can call a function that returns chunks of audio data and
+output the data to the soundcard yourself.
+"""
+
 from setuptools import setup
 
-setup (name = 'pyFluidSynth',
-       version = '1.3',
-       author = 'Nathan Whitehead',
-       author_email = 'nwhitehe@gmail.com',
-       url = 'https://github.com/nwhitehead/pyfluidsynth',
-       description = 'Python bindings for FluidSynth, a MIDI synthesizer that uses SoundFont instruments',
-      long_description = '''
-This module contains python bindings for FluidSynth.  FluidSynth is a
-software synthesizer for generating music.  It works like a MIDI
-synthesizer.  You load patches, set parameters, then send NOTEON and
-NOTEOFF events to play notes.  Instruments are defined in SoundFonts,
-generally files with the extension SF2.  FluidSynth can either be used
-to play audio itself, or you can call a function that returns chunks
-of audio data and output the data to the soundcard yourself.
-''',
-       py_modules = ['fluidsynth'],
-       install_requires = ['future'])
+setup(
+    name='pyFluidSynth',
+    version='1.3',
+    author='Nathan Whitehead',
+    author_email='nwhitehe@gmail.com',
+    url='https://github.com/nwhitehead/pyfluidsynth',
+    description=__doc__.splitlines()[0],
+    long_description="\n".join(__doc__.splitlines()[2:]),
+    py_modules=['fluidsynth'],
+    install_requires =['six'],
+    zip_safe=True
+)

--- a/test/render_smf.py
+++ b/test/render_smf.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Renders a Standard MIDI File (SMF) to an audio file using a given SF2 soundfont."""
+
+import sys
+from os.path import splitext
+from fluidsynth import Synth, Player
+
+
+def main(args=None):
+    if len(args) < 2:
+        return "Usage: render_smf.py <SF2 file> <SMF input file> [<audio output filename>]"
+    else:
+        sf2_filename = args.pop(0)
+        smf_filename = args.pop(0)
+
+    if args:
+        output_filename = args.pop(0)
+    else:
+        output_filename = splitext(smf_filename)[0] + '.wav'
+
+    def progress(fn, ft, num_samples, period_size):
+        if not num_samples % (period_size * 16):
+            print("%d samples written to '%s'." % (num_samples, fn))
+
+    synth = Synth(samplerate=41000)
+    synth.sfload(sf2_filename)
+    player = Player(synth)
+    player.add(smf_filename)
+    player.play()
+    player.render(output_filename, progress_callback=progress)
+    player.delete()
+    synth.delete()
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]) or 0)

--- a/test/render_smf_c.py
+++ b/test/render_smf_c.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""A direct translation of the following C code from the fluidsynth
+documentation::
+
+    #include <fluidsynth.h>
+
+    int main() {
+        fluid_settings_t * settings;
+        fluid_synth_t * synth;
+        fluid_player_t * player;
+        fluid_file_renderer_t * renderer;
+
+        settings = new_fluid_settings();
+        // specify the file to store the audio to
+        // make sure you compiled fluidsynth with libsndfile to get a real wave file
+        // otherwise this file will only contain raw s16 stereo PCM
+        fluid_settings_setstr(settings, "audio.file.name", "test.wav");
+        // use number of samples processed as timing source, rather than the system timer
+        fluid_settings_setstr(settings, "player.timing-source", "sample");
+        // since this is a non-realtime szenario, there is no need to pin the sample data
+        fluid_settings_setint(settings, "synth.lock-memory", 0);
+
+        synth = new_fluid_synth(settings);
+        fluid_synth_sfload(synth, "example.sf2", 0);
+
+        player = new_fluid_player(synth);
+        fluid_player_add(player, "test.mid");
+        fluid_player_play(player);
+
+        renderer = new_fluid_file_renderer(synth);
+
+        while (fluid_player_get_status(player) == FLUID_PLAYER_PLAYING) {
+            if (fluid_file_renderer_process_block(renderer) != FLUID_OK) {
+                break;
+            }
+        }
+
+        // just for sure: stop the playback explicitly and wait until finished
+        fluid_player_stop(player);
+        fluid_player_join(player);
+
+        delete_fluid_file_renderer(renderer);
+        delete_fluid_player(player);
+        delete_fluid_synth(synth);
+        delete_fluid_settings(settings);
+    }
+
+If you put this into a file name ``render_smf.c`` you can compile it with:
+
+    gcc -o render_smf `pkg-config --cflags --libs fluidsynth` render_smf.c
+
+"""
+
+from fluidsynth import *
+
+def main():
+    settings = new_fluid_settings()
+    # specify the file to store the audio to
+    # make sure you compiled fluidsynth with libsndfile to get a real wave file
+    # otherwise this file will only contain raw s16 stereo PCM
+    fluid_settings_setstr(settings, b"audio.file.name", b"test.wav")
+    # use number of samples processed as timing source, rather than the system timer
+    fluid_settings_setstr(settings, b"player.timing-source", b"sample")
+    # since this is a non-realtime szenario, there is no need to pin the sample data
+    fluid_settings_setint(settings, b"synth.lock-memory", 0)
+
+    synth = new_fluid_synth(settings)
+    fluid_synth_sfload(synth, b"example.sf2", 0)
+
+    player = new_fluid_player(synth)
+    fluid_player_add(player, b"test.mid")
+    fluid_player_play(player)
+
+    renderer = new_fluid_file_renderer(synth)
+
+    while fluid_player_get_status(player) == FLUID_PLAYER_PLAYING:
+        if fluid_file_renderer_process_block(renderer) != FLUID_OK:
+            break
+
+    # just for sure: stop the playback explicitly and wait until finished
+    fluid_player_stop(player)
+    fluid_player_join(player)
+
+    delete_fluid_file_renderer(renderer)
+    delete_fluid_player(player)
+    delete_fluid_synth(synth)
+    delete_fluid_settings(settings)
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main() or 0)

--- a/test/render_smf_mem.py
+++ b/test/render_smf_mem.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Renders a Standard MIDI File (SMF) to an audio file using a given SF2 soundfont."""
+
+import sys
+from os.path import splitext
+from fluidsynth import Synth, Player
+
+
+def main(args=None):
+    if len(args) < 2:
+        return "Usage: render_smf.py <SF2 file> <SMF input file> [<audio output filename>]"
+    else:
+        sf2_filename = args.pop(0)
+        smf_filename = args.pop(0)
+
+    if args:
+        output_filename = args.pop(0)
+    else:
+        output_filename = splitext(smf_filename)[0] + '.wav'
+
+    def progress(fn, ft, num_samples, period_size):
+        if not num_samples % (period_size * 16):
+            print("%d samples written to '%s'." % (num_samples, fn))
+
+    synth = Synth(samplerate=41000)
+    synth.sfload(sf2_filename)
+    player = Player(synth)
+
+    with open(smf_filename, 'rb') as fp:
+        data = fp.read()
+
+    player.add_mem(data)
+
+    player.play()
+    player.render(output_filename, progress_callback=progress)
+    player.delete()
+    synth.delete()
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]) or 0)

--- a/test/test1.py
+++ b/test/test1.py
@@ -1,4 +1,6 @@
 import time
+from os.path import dirname, join
+
 import fluidsynth
 
 fs = fluidsynth.Synth()
@@ -7,7 +9,7 @@ fs.start()
 ## Use something like:
 # fs.start(driver="pulseaudio")
 
-sfid = fs.sfload("example.sf2")
+sfid = fs.sfload(join(dirname(__file__), "example.sf2"))
 fs.program_select(0, sfid, 0, 0)
 
 fs.noteon(0, 60, 30)

--- a/test/test2.py
+++ b/test/test2.py
@@ -1,4 +1,6 @@
 import time
+from os.path import dirname, join
+
 import numpy
 import pyaudio
 import fluidsynth
@@ -17,7 +19,7 @@ fl = fluidsynth.Synth()
 # Initial silence is 1 second
 s = numpy.append(s, fl.get_samples(44100 * 1))
 
-sfid = fl.sfload("example.sf2")
+sfid = fs.sfload(join(dirname(__file__), "example.sf2"))
 fl.program_select(0, sfid, 0, 0)
 
 fl.noteon(0, 60, 30)

--- a/test/test2.py
+++ b/test/test2.py
@@ -6,8 +6,8 @@ import fluidsynth
 pa = pyaudio.PyAudio()
 strm = pa.open(
     format = pyaudio.paInt16,
-    channels = 2, 
-    rate = 44100, 
+    channels = 2,
+    rate = 44100,
     output = True)
 
 s = []
@@ -38,6 +38,6 @@ fl.delete()
 
 samps = fluidsynth.raw_audio_string(s)
 
-print len(samps)
-print 'Starting playback'
+print(len(samps))
+print('Starting playback')
 strm.write(samps)

--- a/test/test3.py
+++ b/test/test3.py
@@ -1,4 +1,6 @@
 import time
+from os.path import dirname, join
+
 import fluidsynth
 
 fs = fluidsynth.Synth()
@@ -7,7 +9,7 @@ fs.start()
 ## Use something like:
 # fs.start(driver="pulseaudio")
 
-sfid = fs.sfload("example.sf2")
+sfid = fs.sfload(join(dirname(__file__), "example.sf2"))
 fs.program_select(0, sfid, 0, 0)
 
 fs.noteon(0, 60, 30)

--- a/test/test3.py
+++ b/test/test3.py
@@ -17,6 +17,7 @@ for i in range(10):
     fs.cc(0, 93, 127)
     fs.pitch_bend(0, i * 512)
     time.sleep(0.1)
+
 fs.noteoff(0, 60)
 
 time.sleep(1.0)


### PR DESCRIPTION
This PR is more of a request for comment than an actual merge request.

I heavily extended and changed the module, but I tried to separate the commits into distinct units of functionality. But I also re-formatted and re-arranged the code and the docstrings and I wasn't able to separate these changes from the functional ones. So it might be difficult to cherry-pick from theses changes. But if you are interested in incorporating only some of these changes, I'll see what I can do. I'll also understand if these changes are too extensive to incorporate. I've started this fork mainly with the goal to have a special version of pyfluidsynth to incorporate into an application, but since this could be useful to others I wanted at least to open some kind of PR.

Enhancements & new features:

* Integrated, fixed and enhanced fluidsynth 2 compatibility work done by Bill Peterson (#17).
* Added support for support for fluidsynth MIDI player and renderer and a new `Player` class for an object-oriented API to these.
* Added support for `fluidsynth_settings_get*` functions.
* Enhanced `Synth.settings` to act as a settings retrieval method as well.
* Added support for passing bool values to `Synth.setting`.
* Added support for passing bytes string values to `Synth.settings`.
* Added `all_notes_off` method to `Synth` class.
* Added `RouterRule` class (see below).
* Added MIDI router debug handler function bindings.
* Added tests scripts for fluidsynth MIDI file renderer.
* Described parameter names and types for most important functions and methods with Sphinx-compatible syntax.
* Added module-level constants for fluid setting types (`FLUID_*_TYPE`), MIDI router (`FLUID_MIDI_ROUTER_RULE_*` rule types, and MIDI player state (`FLUID_PLAYER_*`).
* Added module-level constants `AUDIO_DRIVER_NAMES` and `MIDI_DRIVER_NAMES` listing known audio and MIDI drivers.
* Added module-level constant `AUDIO_FILE_TYPES` listing known audio file types for rendering.
* Added `.gitignore` file.
* Added configuration for `flake8`, `pylint` and `isort` QA tools.

Changes:

* Bumped `api_version` to "2.0".
* Updated copyright note at top of module source.
* Replaced use of `future` module for Python 2 compatibility with (simpler) `six` module.
* Changed import of `ctypes` module to explicitly import used names instead
  of star import to enable checking for undefined names with code linters.
* Changed `Synth.setting` to return result of `fluid_setting_set*` calls.
* Changed API to add MIDI router rules to be more object-oriented:

  * Added `RouterRule` class.
  * Added `router_add_rule` method of `Synth` class, which takes a `RouterRule` instance as argument.
  * Removed `router_begin`, `router_end`, `router_chan`, `router_par1`, `router_par2` methods from `Synth` class.
* Updated list of available audio and MIDI drivers in code and documentation.
* `Synth.start()` now raises `ValueError` if unknown driver name is passed.
* Ordered function bindings by fluidsynth header file.
* Re-ordered module level constants, functions and classes to be more
  consistent and in accordance with general Python best practices.
* Re-formatted code for PEP-8 compliance, better consistency, no
  overlong lines and better separation of code blocks.
* Moved notes about changes from module docstring to this change log.

Fixes:

* Replaced raising of undefined `Error` exception with `OSError`.
* Cleaned up docstrings formatting and punctuation.
* Made sure tests scripts find example soundfont when called from another directory.
* Fixed Python 3 incompatibilities in test scripts.
