### PR TITLE
Additional functionality added to fluidsynth.py

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -993,16 +993,9 @@ class Synth:
         fluid_player_set_playback_callback(self.player, self.custom_router_callback, self.synth)
         status = fluid_player_add(self.player, filename.encode())
         if status == FLUID_FAILED: return status
-        playerThread = threading.Thread(target=self.playMidiThread, args=(1,), daemon=True)
-        playerThread.start()
-
-    def playMidiThread(self, name):
         status = fluid_player_play(self.player)
-        if status == FLUID_FAILED: return status
-        fluid_player_join(self.player)
-        delete_fluid_player(self.player)
-        return FLUID_OK
-
+        return status
+    
     def play_midi_stop(self):
         status = fluid_player_stop(self.player)
         if status == FLUID_FAILED: return status


### PR DESCRIPTION
Line 28: Added threading import, needed for playing a midi file
Line 40: Added a search library
Lines 121-149: Added fluid tuning methods (note that tuning dump method is not tested)
Lines 428-449: Added fluid midi event analysis methods
Lines 450-488: Added fluid midi file player methods
Line 660: Added parameter to start() method to support an external midi router
Lines 686-695: Deleted one line, and added code to Synth.start() to support an external midi router
Lines 900-912: Upper limits on key and velocity range corrected
Lines 970-1014: Added methods to Synth to support tuning, event analysis, and midi file playback