### PR TITLE
.tostring() is deprecated so use .tobytes() instead

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -1100,4 +1100,4 @@ def raw_audio_string(data):
 
     """
     import numpy
-    return (data.astype(numpy.int16)).tostring()
+    return (data.astype(numpy.int16)).tobytes()


### PR DESCRIPTION
pytest warning:
```
fluidsynth.py:1103
  /Users/runner/work/pyfluidsynth/pyfluidsynth/fluidsynth.py:1103: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
    return (data.astype(numpy.int16)).tostring()
```
* https://docs.python.org/3/library/array.html#array.array.tobytes