### PR TITLE
GitHub Action to spellcheck and lint Python code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: ci
 on: [pull_request, push]
 jobs:
+  codespell_and_ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install --user codespell[toml] ruff
+      - run: codespell **/*.py **/*.txt --skip="venv/lib/python3*"
+      - run: ruff check --output-format=github --target-version=py38 .
   ci:
     strategy:
       fail-fast: false

--- a/test/sequencerTest.py
+++ b/test/sequencerTest.py
@@ -2,7 +2,6 @@
 
 import time
 import fluidsynth
-from ctypes import *
 
 seqduration = 1000
 


### PR DESCRIPTION
This Action uses minimal steps to run in ~5 seconds to rapidly:
*  use `codespell` to look for typos in the codebase, and
* use `ruff` to lint Python code and provide intuitive GitHub Annotations to contributors.

Tools:
* https://github.com/codespell-project/codespell#readme
* https://docs.astral.sh/ruff

---

The wildcard import `from ctypes import *` is not a good idea because it can hide `undefined name` errors:
* https://peps.python.org/pep-0008/#imports
* https://docs.astral.sh/ruff/rules/undefined-local-with-import-star-usage/

There are several `undefined names` to be fixed.  Each of these will raise `NameError` if executed.

% `ruff check .`
```
fluidsynth.py:772:75: F821 Undefined name `chan`
fluidsynth.py:888:12: F821 Undefined name `fluid_synth_set_chorus_speed`
fluidsynth.py:889:20: F821 Undefined name `fluid_synth_set_chorus_speed`
fluidsynth.py:893:12: F821 Undefined name `fluid_synth_set_chorus_depth`
fluidsynth.py:894:20: F821 Undefined name `fluid_synth_set_chorus_depth`
fluidsynth.py:1002:64: F821 Undefined name `name`
fluidsynth.py:1002:83: F821 Undefined name `name`
Found 7 errors.
```
% `ruff rule F821`
# undefined-name (F821)

Derived from the **Pyflakes** linter.

## What it does
Checks for uses of undefined names.

## Why is this bad?
An undefined name is likely to raise `NameError` at runtime.

## Example
```python
def double():
    return n * 2  # raises `NameError` if `n` is undefined when `double` is called
```

Use instead:
```python
def double(n):
    return n * 2
```

## References
- [Python documentation: Naming and binding](https://docs.python.org/3/reference/executionmodel.html#naming-and-binding)