### PR TITLE
Ruff rules for whitespace

### DIFF
--- a/test/sequencerTest.py
+++ b/test/sequencerTest.py
@@ -6,54 +6,54 @@ import fluidsynth
 seqduration = 1000
 
 def schedule_next_callback():
-	# I want to be called back before the end of the next sequence
-	callbackdate = int(now + seqduration/2)
-	sequencer.timer(callbackdate, dest=mySeqID)
+    # I want to be called back before the end of the next sequence
+    callbackdate = int(now + seqduration/2)
+    sequencer.timer(callbackdate, dest=mySeqID)
 
 def schedule_next_sequence():
-	global now
-	# the sequence to play
-	# the beat : 2 beats per sequence
-	sequencer.note(int(now + seqduration * 1/2), 0, 60, duration=250, velocity=80, dest=synthSeqID)
-	sequencer.note(int(now + seqduration * 2/2), 0, 60, duration=250, velocity=80, dest=synthSeqID)
-	# melody
-	sequencer.note(int(now + seqduration*1/10), 1, 45, duration=250, velocity=int(127*2/3), dest=synthSeqID)
-	sequencer.note(int(now + seqduration*4/10), 1, 50, duration=250, velocity=int(127*2/3), dest=synthSeqID)
-	sequencer.note(int(now + seqduration*8/10), 1, 55, duration=250, velocity=int(127*3/3), dest=synthSeqID)
-	# so that we are called back early enough to schedule the next sequence
-	schedule_next_callback()
-	
-	now = now + seqduration
+    global now
+    # the sequence to play
+    # the beat : 2 beats per sequence
+    sequencer.note(int(now + seqduration * 1/2), 0, 60, duration=250, velocity=80, dest=synthSeqID)
+    sequencer.note(int(now + seqduration * 2/2), 0, 60, duration=250, velocity=80, dest=synthSeqID)
+    # melody
+    sequencer.note(int(now + seqduration*1/10), 1, 45, duration=250, velocity=int(127*2/3), dest=synthSeqID)
+    sequencer.note(int(now + seqduration*4/10), 1, 50, duration=250, velocity=int(127*2/3), dest=synthSeqID)
+    sequencer.note(int(now + seqduration*8/10), 1, 55, duration=250, velocity=int(127*3/3), dest=synthSeqID)
+    # so that we are called back early enough to schedule the next sequence
+    schedule_next_callback()
+
+    now = now + seqduration
 
 def seq_callback(time, event, seq, data):
-	schedule_next_sequence()
+    schedule_next_sequence()
 
 def local_file_path(file_name: str) -> str:
-	"""
-	Return a file path to a file that is in the same directory as this file.
-	"""
-	from os.path import dirname, join
+    """
+    Return a file path to a file that is in the same directory as this file.
+    """
+    from os.path import dirname, join
 
-	return join(dirname(__file__), file_name)
+    return join(dirname(__file__), file_name)
 
 if __name__=="__main__":
-	global sequencer, fs, mySeqID, synthSeqID, now
-	fs = fluidsynth.Synth()
-	fs.start()
-	# you might have to use other drivers:
-	#fs.start(driver="alsa", midi_driver="alsa_seq")
+    global sequencer, fs, mySeqID, synthSeqID, now
+    fs = fluidsynth.Synth()
+    fs.start()
+    # you might have to use other drivers:
+    # fs.start(driver="alsa", midi_driver="alsa_seq")
 
-	sfid = fs.sfload(local_file_path("example.sf2"))
-	fs.program_select(0, sfid, 0, 0)
-	fs.program_select(1, sfid, 0, 0) # use the same program for channel 2 for cheapness
+    sfid = fs.sfload(local_file_path("example.sf2"))
+    fs.program_select(0, sfid, 0, 0)
+    fs.program_select(1, sfid, 0, 0) # use the same program for channel 2 for cheapness
 
-	sequencer = fluidsynth.Sequencer()
-	synthSeqID = sequencer.register_fluidsynth(fs)
-	mySeqID = sequencer.register_client("mycallback", seq_callback)
-	now = sequencer.get_tick()
-	schedule_next_sequence()
-	
-	time.sleep(10)
-	
-	sequencer.delete()
-	fs.delete()
+    sequencer = fluidsynth.Sequencer()
+    synthSeqID = sequencer.register_fluidsynth(fs)
+    mySeqID = sequencer.register_client("mycallback", seq_callback)
+    now = sequencer.get_tick()
+    schedule_next_sequence()
+
+    time.sleep(10)
+
+    sequencer.delete()
+    fs.delete()

--- a/test/test1.py
+++ b/test/test1.py
@@ -2,12 +2,12 @@ import time
 import fluidsynth
 
 def local_file_path(file_name: str) -> str:
-	"""
-	Return a file path to a file that is in the same directory as this file.
-	"""
-	from os.path import dirname, join
+    """
+    Return a file path to a file that is in the same directory as this file.
+    """
+    from os.path import dirname, join
 
-	return join(dirname(__file__), file_name)
+    return join(dirname(__file__), file_name)
 
 fs = fluidsynth.Synth()
 fs.start()

--- a/test/test2.py
+++ b/test/test2.py
@@ -3,18 +3,18 @@ import pyaudio
 import fluidsynth
 
 def local_file_path(file_name: str) -> str:
-	"""
-	Return a file path to a file that is in the same directory as this file.
-	"""
-	from os.path import dirname, join
+    """
+    Return a file path to a file that is in the same directory as this file.
+    """
+    from os.path import dirname, join
 
-	return join(dirname(__file__), file_name)
+    return join(dirname(__file__), file_name)
 
 pa = pyaudio.PyAudio()
 strm = pa.open(
     format = pyaudio.paInt16,
-    channels = 2, 
-    rate = 44100, 
+    channels = 2,
+    rate = 44100,
     output = True)
 
 s = []

--- a/test/test3.py
+++ b/test/test3.py
@@ -3,12 +3,12 @@ import time
 import fluidsynth
 
 def local_file_path(file_name: str) -> str:
-	"""
-	Return a file path to a file that is in the same directory as this file.
-	"""
-	from os.path import dirname, join
+    """
+    Return a file path to a file that is in the same directory as this file.
+    """
+    from os.path import dirname, join
 
-	return join(dirname(__file__), file_name)
+    return join(dirname(__file__), file_name)
 
 fs = fluidsynth.Synth()
 fs.start()

--- a/test/test4.py
+++ b/test/test4.py
@@ -2,12 +2,12 @@ import time
 import fluidsynth
 
 def local_file_path(file_name: str) -> str:
-	"""
-	Return a file path to a file that is in the same directory as this file.
-	"""
-	from os.path import dirname, join
+    """
+    Return a file path to a file that is in the same directory as this file.
+    """
+    from os.path import dirname, join
 
-	return join(dirname(__file__), file_name)
+    return join(dirname(__file__), file_name)
 
 fs = fluidsynth.Synth()
 fs.start()


### PR DESCRIPTION
% `ruff check --select=W --statistics`
```
50	W191	[ ] Indentation contains tabs
 3	W293	[*] Blank line contains whitespace
 2	W291	[*] Trailing whitespace
```
% `ruff rule W191`
# tab-indentation (W191)

Derived from the **pycodestyle** linter.

## What it does
Checks for indentation that uses tabs.

## Why is this bad?
According to [PEP 8], spaces are preferred over tabs (unless used to remain
consistent with code that is already indented with tabs).

## Example
```python
if True:
	a = 1
```

Use instead:
```python
if True:
    a = 1
```

## Formatter compatibility
We recommend against using this rule alongside the [formatter]. The
formatter enforces consistent indentation, making the rule redundant.

The rule is also incompatible with the [formatter] when using
`format.indent-style="tab"`.

[PEP 8]: https://peps.python.org/pep-0008/#tabs-or-spaces
[formatter]: https://docs.astral.sh/ruff/formatter
