### PR TITLE
Add fix to locate Homebrew-installed libfluidsynth on Apple silicon

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -69,6 +69,20 @@ def load_libfluidsynth(debug_print: bool = False) -> str:
             if debug_print:
                 print(f"'{lib_name}' was loaded as {lib}.")
             return lib
+
+    # On macOS on Apple silicon, non-Homebrew Python distributions fail to locate
+    # homebrew-installed instances of FluidSynth. This workaround addresses this.
+    if lib is None:
+        import sys, subprocess
+        if sys.platform == "darwin":
+            try:
+                prefix = subprocess.check_output(["brew", "--prefix"]).decode("utf8").strip()
+                lib = os.path.join(prefix, "lib", "libfluidsynth.dylib")
+                if os.path.exists(lib):
+                    return lib
+            # Raised if brew was not located
+            except FileNotFoundError:
+                pass
     raise ImportError("Couldn't find the FluidSynth library.")
 
 lib = load_libfluidsynth()


### PR DESCRIPTION
On macOS on Apple silicon, non-Homebrew Python distributions fail to locate homebrew-installed instances of FluidSynth and raise an `ImportError("Couldn't find the FluidSynth library.")`. This workaround addresses this.

Thanks for the great library!