### PR TITLE
enable midi -> audio (efficiently)

### DIFF
--- a/test/test7.py
+++ b/test/test7.py
@@ -1,0 +1,17 @@
+import fluidsynth
+
+
+def local_file_path(file_name: str) -> str:
+    """
+    Return a file path to a file that is in the same directory as this file.
+    """
+    from os.path import dirname, join
+
+    return join(dirname(__file__), file_name)
+
+fs = fluidsynth.Synth()
+sfid = fs.sfload(local_file_path("example.sf2"))
+fs.midi2audio(local_file_path("1080-c01.mid"), local_file_path("1080-c01.wav"))
+# A Synth object can synthesize multiple files. For example:
+# fs.midi2audio(local_file_path("1080-c02.mid"), local_file_path("1080-c02.wav"))
+# fs.midi2audio(local_file_path("1080-c03.mid"), local_file_path("1080-c03.wav"))


### PR DESCRIPTION
I have a need to synthesize a large number of audio files from midi using fluidsynth. However, pyfluidsynth haven't implemented this.
In the Python library 'midi2audio', the author fulfilled "audio file synthesis" using the command-line function of fluidsynth. However, a large amount of time is required for one execution, and I find that it is creating the synth (along with loading soundfont) that takes up the majority of the time. So I digged into the source code and now pyfluidsynth can synthesize lots of midi files with only one load, greatly accelerating the process.
test7.py shows how to use the new function.