### PR TITLE
enable midi -> audio (re pull)

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -703,8 +703,6 @@ class Synth:
         self.midi_driver = None
         self.router = None
         self.custom_router_callback = None
-    def __del__(self):
-        self.delete()
     def setting(self, opt, val):
         """change an arbitrary synth setting, type-smart"""
         if isinstance(val, (str, bytes)):

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -1082,7 +1082,7 @@ class Synth:
 
     def player_set_tempo(self, tempo_type, tempo):
         return fluid_player_set_tempo(self.player, tempo_type, tempo)
-    
+
     def midi2audio(self, midifile, audiofile = "output.wav"):
         """Convert a midi file to an audio file"""
         self.setting("audio.file.name", audiofile)

--- a/test/test7.py
+++ b/test/test7.py
@@ -1,0 +1,17 @@
+import fluidsynth
+
+
+def local_file_path(file_name: str) -> str:
+    """
+    Return a file path to a file that is in the same directory as this file.
+    """
+    from os.path import dirname, join
+
+    return join(dirname(__file__), file_name)
+
+fs = fluidsynth.Synth()
+sfid = fs.sfload(local_file_path("example.sf2"))
+fs.midi2audio(local_file_path("1080-c01.mid"), local_file_path("1080-c01.wav"))
+# A Synth object can synthesize multiple files. For example:
+# fs.midi2audio(local_file_path("1080-c02.mid"), local_file_path("1080-c02.wav"))
+# fs.midi2audio(local_file_path("1080-c03.mid"), local_file_path("1080-c03.wav"))

--- a/test/test7.py
+++ b/test/test7.py
@@ -15,3 +15,5 @@ fs.midi2audio(local_file_path("1080-c01.mid"), local_file_path("1080-c01.wav"))
 # A Synth object can synthesize multiple files. For example:
 # fs.midi2audio(local_file_path("1080-c02.mid"), local_file_path("1080-c02.wav"))
 # fs.midi2audio(local_file_path("1080-c03.mid"), local_file_path("1080-c03.wav"))
+
+fs.delete()


### PR DESCRIPTION
recreate pull request #83 
This error originates from a space: [fluidsynth.py:1085:1: W293 Blank line contains whitespace](https://github.com/nwhitehead/pyfluidsynth/actions/runs/12204520027), and I have removed the extra 'whitespace'.
I test my code with the latest fluidsynth release and python 3.10, and it works well.