### PR TITLE
GitHub Actions: Add ubuntu-24.04-arm and windows-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
     needs: [codespell_and_ruff]
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:  # macos-13 in Intel, macos-latest is Apple Silicon ARM
         os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-2025]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:  # macos-13 in Intel, macos-latest is Apple Silicon ARM
-        os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-2025]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
       - if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install fluidsynth python3-pyaudio portaudio19-dev libasound-dev
+          sudo apt-get install fluidsynth libasound-dev portaudio19-dev python3-pyaudio
       - if: runner.os == 'macOS'
         run: |
           brew install fluid-synth

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",  # Windows: https://github.com/nwhitehead/pyfluidsynth/issues/77
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = [ "numpy" ]
 


### PR DESCRIPTION
```diff
    strategy:
      fail-fast: false
      matrix:  # macos-13 in Intel, macos-latest is Apple Silicon ARM
-       os: [macos-13, macos-latest, ubuntu-latest, windows-latest]
+       os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-2025]
```
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories