### PR TITLE
Add PEP 723 headers to the test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,39 +35,13 @@ jobs:
         run: |
           brew install fluid-synth
           echo "DYLD_LIBRARY_PATH=$(brew --prefix fluid-synth)/lib/" >> $GITHUB_ENV
+      # TODO(cclauss): Remove version when fluidsynth#1510 is fixed.
+      # https://github.com/FluidSynth/fluidsynth/issues/1510
       - if: runner.os == 'Windows'
-        run: choco install fluidsynth
-      - if: runner.os == 'Windows'
-        run: ls C:\tools\fluidsynth\bin\libfluidsynth-3.dll
-      - if: runner.os == 'Windows'
-        run: |
-          dir C:\tools
-          dir C:\tools\fluidsynth
-          dir C:\tools\fluidsynth\bin
-          ls C:\tools\fluidsynth\bin\fluidsynth.exe
-          ls C:\tools\fluidsynth\bin\libfluidsynth-3.dll
-        #  fluidsynth.exe --version
-        #  ls /mnt/d/tools/fluidsynth/bin/fluidsynth.exe
-        #  ls /mnt/d/tools/fluidsynth/bin/libfluidsynth-3.dll
-        #  /mnt/d/tools/fluidsynth/bin/fluidsynth.exe --help
-        #  C:\tools\fluidsynth\bin\fluidsynth.exe --help
-        #  echo "PATH=$PATH"
-        #  C:\tools\fluidsynth\bin\fluidsynth.exe --version
+        run: choco install fluidsynth --version 2.4.3
       - run: uv pip install --editable .
       - shell: python
         run: |
-          from pathlib import Path
-
-          dll_path = Path("C:/tools/fluidsynth/bin/libfluidsynth-3.dll")
-          if dll_path.exists():
-              print(f"Found {dll_path}")
-          else:
-              print(f"Did not find {dll_path}")
-          dll_path = dll_path.resolve()
-          if dll_path.exists():
-              print(f"Found {dll_path}")
-          else:
-              print(f"Did not find {dll_path}")
           import fluidsynth
           print(fluidsynth)
           print(dir(fluidsynth))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,37 @@ jobs:
           echo "DYLD_LIBRARY_PATH=$(brew --prefix fluid-synth)/lib/" >> $GITHUB_ENV
       - if: runner.os == 'Windows'
         run: choco install fluidsynth
+      - if: runner.os == 'Windows'
+        run: ls C:\tools\fluidsynth\bin\libfluidsynth-3.dll
+      - if: runner.os == 'Windows'
+        run: |
+          dir C:\tools
+          dir C:\tools\fluidsynth
+          dir C:\tools\fluidsynth\bin
+          ls C:\tools\fluidsynth\bin\fluidsynth.exe
+          ls C:\tools\fluidsynth\bin\libfluidsynth-3.dll
+        #  fluidsynth.exe --version
+        #  ls /mnt/d/tools/fluidsynth/bin/fluidsynth.exe
+        #  ls /mnt/d/tools/fluidsynth/bin/libfluidsynth-3.dll
+        #  /mnt/d/tools/fluidsynth/bin/fluidsynth.exe --help
+        #  C:\tools\fluidsynth\bin\fluidsynth.exe --help
+        #  echo "PATH=$PATH"
+        #  C:\tools\fluidsynth\bin\fluidsynth.exe --version
       - run: uv pip install --editable .
       - shell: python
         run: |
+          from pathlib import Path
+
+          dll_path = Path("C:/tools/fluidsynth/bin/libfluidsynth-3.dll")
+          if dll_path.exists():
+              print(f"Found {dll_path}")
+          else:
+              print(f"Did not find {dll_path}")
+          dll_path = dll_path.resolve()
+          if dll_path.exists():
+              print(f"Found {dll_path}")
+          else:
+              print(f"Did not find {dll_path}")
           import fluidsynth
           print(fluidsynth)
           print(dir(fluidsynth))

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -37,7 +37,6 @@ from ctypes import (
     c_short,
     c_uint,
     c_void_p,
-    cdll,
     create_string_buffer,
 )
 from ctypes.util import find_library
@@ -46,10 +45,8 @@ from ctypes.util import find_library
 # https://docs.python.org/3/library/os.html#os.add_dll_directory
 if hasattr(os, 'add_dll_directory'):  # Python 3.8+ on Windows only
     os.add_dll_directory(os.getcwd())
-    # os.add_dll_directory('C:/tools/fluidsynth/bin')
     os.add_dll_directory('C:\\tools\\fluidsynth\\bin')
     # Workaround bug in find_library, it doesn't recognize add_dll_directory
-    # os.environ['PATH'] += ';C:/tools/fluidsynth/bin'
     os.environ['PATH'] += ';C:\\tools\\fluidsynth\\bin'
 
 # A function to find the FluidSynth library
@@ -86,21 +83,7 @@ lib = load_libfluidsynth()
 
 # Dynamically link the FluidSynth library
 # Architecture (32-/64-bit) must match your Python version
-try:
-    _fl = CDLL(lib)
-except FileNotFoundError:
-    try:
-        _fl = cdll.LoadLibrary(lib)
-    except FileNotFoundError as e:
-        from pathlib import Path
-
-        lib_path = Path(lib).resolve()
-        raise FileNotFoundError(
-            f"Could not load the FluidSynth library: {lib}. "
-            f"{lib_path = }, {lib_path.exists() = }. "
-            f"{e = }. "
-            "Make sure it is installed and accessible in your system's PATH.",
-        ) from e
+_fl = CDLL(lib)
 
 # Helper function for declaring function prototypes
 def cfunc(name, result, *args):

--- a/test/modulatorTest.py
+++ b/test/modulatorTest.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyfluidsynth",
+# ]
+# ///
+
 import unittest
 
 import fluidsynth as fs

--- a/test/modulatorTest.py
+++ b/test/modulatorTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/sequencerTest.py
+++ b/test/sequencerTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/sequencerTest.py
+++ b/test/sequencerTest.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyfluidsynth",
+# ]
+# ///
+
 import time
 
 import fluidsynth

--- a/test/test1.py
+++ b/test/test1.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyfluidsynth",
+# ]
+# ///
+
 import time
 
 import fluidsynth

--- a/test/test1.py
+++ b/test/test1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/test2.py
+++ b/test/test2.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "numpy",
+#     "pyaudio",
+#     "pyfluidsynth",
+# ]
+# ///
+
 import numpy
 import pyaudio
 

--- a/test/test2.py
+++ b/test/test2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/test3.py
+++ b/test/test3.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyfluidsynth",
+# ]
+# ///
+
 import time
 
 import fluidsynth

--- a/test/test3.py
+++ b/test/test3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/test4.py
+++ b/test/test4.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyfluidsynth",
+# ]
+# ///
+
 import time
 
 import fluidsynth

--- a/test/test4.py
+++ b/test/test4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/test5.py
+++ b/test/test5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/test5.py
+++ b/test/test5.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyfluidsynth",
+# ]
+# ///
+
+# Runtime is 2:49.45
+
 import time
 
 import fluidsynth

--- a/test/test6.py
+++ b/test/test6.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "numpy",
+#     "pyaudio",
+#     "pyfluidsynth",
+# ]
+# ///
+
 import numpy
 import pyaudio
 

--- a/test/test6.py
+++ b/test/test6.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/test7.py
+++ b/test/test7.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
 
 # /// script
 # requires-python = ">=3.9"

--- a/test/test7.py
+++ b/test/test7.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pyfluidsynth",
+# ]
+# ///
+
 import fluidsynth
 
 


### PR DESCRIPTION
https://peps.python.org/pep-0723 enables Python files to have a header like:
```python
# /// script
# requires-python = ">=3.9"
# dependencies = [
#     "pyfluidsynth",
# ]
# ///
```
to Python scripts, which enables:
`pipx run test/test5.py` or
`uv run --script test/test5.py`.

When this command is run, `pipx` or `uv` will import the `dependencies` from PyPI, put them in an isolated `venv`, and then run the script in that `venv`.

https://thisdavej.com/share-python-scripts-like-a-pro-uv-and-pep-723-for-easy-deployment

---

Also, a workaround for
* FluidSynth/fluidsynth#1510 should be fixed in  fluidsynth >= v2.4.5
    * https://github.com/FluidSynth/fluidsynth/releases 