### PR TITLE
Run tests on the latest stable version of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
         run: choco install fluidsynth
       - run: uv pip install --editable .
       - shell: python
+        name: "import fluidsynth on ${{ matrix.os }} on ${{ runner.arch }}"
         run: |
+          import sys
+          print("python{}.{}.{} -m pip install fluidsynth".format(*sys.version_info))
           import fluidsynth
           print(fluidsynth)
           print(dir(fluidsynth))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,10 @@ jobs:
       - shell: python
         name: "import fluidsynth on ${{ matrix.os }} on ${{ runner.arch }}"
         run: |
-          import os, sys
-          print("OS:", os.name, sys.platform)
-          print(os.getenv("matrix"), os.getenv("runner"))
-          print("python{}.{}.{} -m pip install fluidsynth".format(*sys.version_info))
           import fluidsynth
+          import os, sys
+          print(f"{os.environ = }")
+          print("python{}.{}.{} -m pip install fluidsynth".format(*sys.version_info))
           print(fluidsynth)
           print(dir(fluidsynth))
       # NOTE: The files in test/ are NOT unit tests or pytests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
       - uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true
@@ -43,10 +46,9 @@ jobs:
       - shell: python
         name: "import fluidsynth on ${{ matrix.os }} on ${{ runner.arch }}"
         run: |
+          import os
+          print(f"import fluidsynth on {os.getenv('ImageOS')} on {os.getenv('RUNNER_ARCH')}")
           import fluidsynth
-          import os, sys
-          print(f"{os.environ = }")
-          print("python{}.{}.{} -m pip install fluidsynth".format(*sys.version_info))
           print(fluidsynth)
           print(dir(fluidsynth))
       # NOTE: The files in test/ are NOT unit tests or pytests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:  # macos-13 in Intel, macos-latest is Apple Silicon ARM
-        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,19 @@ jobs:
       matrix:  # macos-13 in Intel, macos-latest is Apple Silicon ARM
         os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
         # `windows-11-arm` is blocked by CristiFati/pyaudio#15
+        python-version: [3.14]
+        exclude:
+          - os: windows-latest
+            python-version: 3.14
+        include:
+          - os: windows-latest
+            python-version: 3.13
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.14
+          python-version: ${{ matrix.python-version }}
           allow-prereleases: true
       - uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ jobs:
       - shell: python
         name: "import fluidsynth on ${{ matrix.os }} on ${{ runner.arch }}"
         run: |
-          import sys
+          import os, sys
+          print("OS:", os.name, sys.platform)
+          print(os.getenv("matrix"), os.getenv("runner"))
           print("python{}.{}.{} -m pip install fluidsynth".format(*sys.version_info))
           import fluidsynth
           print(fluidsynth)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:  # macos-13 in Intel, macos-latest is Apple Silicon ARM
-        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm]
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
+        # `windows-11-arm` is blocked by CristiFati/pyaudio#15
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.x
+          python-version: 3.14
+          allow-prereleases: true
       - uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@v3
+        with:
+          version: latest
       - run: pipx run 'codespell[toml]' **/*.py **/*.txt --skip="venv/lib/python3*"
 
   ci:
@@ -19,15 +21,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:  # macos-13 in Intel, macos-latest is Apple Silicon ARM
-        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-2025]
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
         with:
           activate-environment: true
-          python-version: 3.13
-          version: "latest"
+          version: latest
       - if: runner.os == 'Linux'
         run: |
           sudo apt-get update
@@ -76,8 +77,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
         with:
-          python-version: 3.13
-          version: "latest"
+          version: latest
 
       - name: Clean previous builds
         run: rm -rf dist
@@ -114,6 +114,5 @@ jobs:
       - run: ls -la dist || true
       - uses: astral-sh/setup-uv@v6
         with:
-          python-version: 3.13
-          version: "latest"
+          version: latest
       - run: uv publish

--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -52,7 +52,7 @@ if hasattr(os, 'add_dll_directory'):  # Python 3.8+ on Windows only
 
 # A function to find the FluidSynth library
 # (mostly needed for Windows distributions of libfluidsynth supplied with QSynth)
-def find_libfluidsynth(debug_print: bool = False) -> str:
+def find_libfluidsynth(debug_print: bool = os.getenv("CI")) -> str:
     r"""
     macOS X64:
     * 'fluidsynth' was found at /usr/local/opt/fluid-synth/lib/libfluidsynth.dylib.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ upgrade = true
 
 [tool.ruff]
 line-length = 123
+target-version = "py39"
 lint.select = [
   "AIR",   # Airflow
   "ASYNC", # flake8-async


### PR DESCRIPTION
Python 3.14rc2 works everywhere but Windows.
* CristiFati/pyaudio#15

Automated testing should tell us if things are broken on the latest stable version of Python before users do.
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input
> [x-ranges](https://github.com/npm/node-semver#x-ranges-12x-1x-12-) to specify the latest stable version of Python (for the specified major version): 