### PR TITLE
Free threaded Python: Run pytest-run-parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
       - run: pytest
       - run: uv pip install pytest-run-parallel
       - run: pytest --iterations=8 --parallel-threads=auto
+        env:
+          PYTEST_RUN_PARALLEL_VERBOSE: 1
       # Import fluidsynth and document OS-specific values
       - shell: python
         name: "import fluidsynth on ${{ matrix.os }} on ${{ runner.arch }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
       - run: uv pip install pytest
       - run: uv pip install --editable .
       - run: pytest
+      - run: uv pip install pytest-run-parallel
+      - run: pytest --iterations=8 --parallel-threads=auto
       # Import fluidsynth and document OS-specific values
       - shell: python
         name: "import fluidsynth on ${{ matrix.os }} on ${{ runner.arch }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - run: pytest
       - run: uv pip install pytest-run-parallel
       - run: pytest --iterations=8 --parallel-threads=auto
-        if: runner.os == 'Linux'  # Segmentation faults on macOS
+        if: runner.os != 'macOS'  # Segmentation faults on macOS
         env:  # No issues on Py3.14 but there are on earlier versions
           PYTEST_RUN_PARALLEL_VERBOSE: 1
       # Import fluidsynth and document OS-specific values

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
             python-version: '3.12'
           - os: ubuntu-latest
             python-version: '3.10'
-          # - os: windows-latest
-          #   python-version: '3.13'
+          - os: windows-latest
+            python-version: '3.13'
         exclude:
           - os: windows-latest
             python-version: '3.14'
@@ -62,7 +62,8 @@ jobs:
       - run: pytest
       - run: uv pip install pytest-run-parallel
       - run: pytest --iterations=8 --parallel-threads=auto
-        env:
+        if: runner.os == 'Linux'  # Segmentation faults on macOS
+        env:  # No issues on Py3.14 but there are on earlier versions
           PYTEST_RUN_PARALLEL_VERBOSE: 1
       # Import fluidsynth and document OS-specific values
       - shell: python


### PR DESCRIPTION
To be confident about compatibility with free-threaded Python, it is recommended to test with [`pytest-run-parallel`](https://github.com/Quansight-Labs/pytest-run-parallel).
https://py-free-threading.github.io/testing

Something like:
% `uvx --with=pytest-run-parallel pytest --iterations=8 --parallel-threads=auto` 