### PR TITLE
Change preset name decoding from ASCII to Latin-1

### DIFF
--- a/fluidsynth.py
+++ b/fluidsynth.py
@@ -885,7 +885,7 @@ class Synth:
             preset=fluid_sfont_get_preset(sfont, bank, prenum)
             if not preset:
                 return None
-            return fluid_preset_get_name(preset).decode('ascii')
+            return fluid_preset_get_name(preset).decode('latin-1')
         else:
             return None
     def router_clear(self):


### PR DESCRIPTION
This PR makes a one-line change that replaces `"ascii"` decoding with `"latin-1"` decoding in the `sfpreset_name` method.
This change preserves all previous behavior for valid ASCII data because:

- Latin-1 is a strict superset of ASCII.
- For bytes `0–127`, Latin-1 decoding behaves identically to ASCII decoding.
- The only difference is that Latin-1 can also decode bytes `128–255`, while ASCII raises a `UnicodeDecodeError` for those values.

This matters because some SoundFont (`.sf2`) files contain preset names with non-ASCII characters, which causes errors under ASCII decoding. Latin-1 decoding correctly recovers these characters.
The following code demonstrates that Latin-1 exactly reproduces ASCII behavior for all valid ASCII bytes:
```python
data = bytes(range(128))
assert data.decode("ascii") == data.decode("latin-1")
```
Here are a few examples of bytes (I met) that caused ASCII decoding errors, along with their correct Latin-1 decodings:
```
b"\xe8" -> è
b"\xe9" -> é
b"\xf6" -> ö
```
I am happy to share the `.sf2` files that demonstrate this issue if needed.