### PR TITLE
Upgrade to ruff-action v4.0.0 immutable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4.0.0
         with:
           version: latest
       - run: pipx run 'codespell[toml]' **/*.py **/*.txt --skip="venv/lib/python3*"


### PR DESCRIPTION
https://github.com/astral-sh/ruff-action/releases  Dependabot gets confused about upgrading from a mutable release to an immutable release.  However, after this PR it will do the right thing when the Action gets a new release.